### PR TITLE
Logic fixes in comparison

### DIFF
--- a/crates/poker/src/hand_rankings.rs
+++ b/crates/poker/src/hand_rankings.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use cards::card::{Card, Rank, Suit};
 
-#[derive(Clone, Copy, Debug, Eq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq)]
 pub enum HandRank {
     /// Simple value of the card.
     /// Lowest: 2 – Highest: Ace.
@@ -179,6 +179,12 @@ impl Ord for HandRank {
             (_, HandRank::StraightFlush(_)) => Ordering::Less,
             (HandRank::StraightFlush(_), _) => Ordering::Greater,
         }
+    }
+}
+
+impl PartialOrd for HandRank {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/poker/src/hand_rankings.rs
+++ b/crates/poker/src/hand_rankings.rs
@@ -2971,4 +2971,19 @@ mod tests {
         let hand_rank2 = rank_hand(cards2);
         assert_eq!(hand_rank2, ace_high_straight_flush);
     }
+
+    #[test]
+    fn eq_matches_ord() {
+        // This should be true for all HandRank pairs.
+        let hr1 : HandRank = HandRank::HighCard(card!(Seven, Diamond));
+        let hr2 : HandRank = HandRank::HighCard(card!(Seven, Club));
+
+        if hr1.cmp(&hr2) == Ordering::Equal {
+            assert!(hr1.eq(&hr1));
+        }
+        if hr1.eq(&hr2) {
+            assert!(hr1.cmp(&hr2) == Ordering::Equal);
+        }
+    }
+
 }

--- a/crates/poker/src/hand_rankings.rs
+++ b/crates/poker/src/hand_rankings.rs
@@ -112,8 +112,14 @@ impl Ord for HandRank {
         match (self, other) {
             (HandRank::HighCard(_), _) => Ordering::Less,
             (_, HandRank::HighCard(_)) => Ordering::Greater,
+
+            (HandRank::Pair(cards1), HandRank::Pair(cards2)) => {
+                cards1[0].rank.cmp(&cards2[0].rank)
+            }
             (HandRank::Pair(_), _) => Ordering::Less,
             (_, HandRank::Pair(_)) => Ordering::Greater,
+
+
             (HandRank::TwoPair(_), _) => Ordering::Less,
             (_, HandRank::TwoPair(_)) => Ordering::Greater,
             (HandRank::ThreeOfAKind(_), _) => Ordering::Less,


### PR DESCRIPTION
## Fix: `Ord` / `PartialOrd` consistency

[The docs](https://doc.rust-lang.org/std/cmp/trait.Ord.html) note:

> It’s easy to accidentally make `cmp` and `partial_cmp` disagree by deriving some of the traits and manually implementing others.

This was the case here: the [derived `PartialOrd`](https://doc.rust-lang.org/std/cmp/trait.Ord.html#lexicographical-comparison) acted on a [lexicographical ordering of fields](https://doc.rust-lang.org/std/cmp/trait.Ord.html#lexicographical-comparison), rather than on the semantic ordering from `Ord`.

The fix here is to make `PartialOrd` use the implementation from `Ord` -- as suggested [here](https://doc.rust-lang.org/std/cmp/trait.Ord.html#lexicographical-comparison), though unfortunately that's not what `cargo` suggests.

## Hints at: `Eq` and `Ord` consistency

The test highlights a remaining issue, that cause a couple tests to fail: inconsistency between `PartialEq` and `Ord`.

[The docs say](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html)

> The methods of \[`PartialEq`] must be consistent with... those of `PartialEq`.

However, there are some cases where `a.eq(&b)` returns `true`, but `a.cmp(&b)` returns `Ordering::Less`.

The fix for `HandRank::Pair` gives the pattern for the other fixes:
- In `cmp`, add an explicit match arm for "the same `HandRank` variant in both variables"
- ...before the other cases, since the placeholder `_` will otherwise catch it first

The final step of this would be to implement `PartialEq` in terms of `Ord`.

## Other random thoughts

Things I mentioned, but leaving here as a reminder / for follow-up:

- Two cents: the way I'd probably implement this is with a function `fn compare_texas_hands(a: &Hand, b: &Hand) -> Ordering` -- which internally computes the `HandRank`, uses them, and falls back to the kicker if needed. This might be a little easier to test / maintain / reason about than having to put together a full game to test particular cases; and might make more of the game logic a little more compartmentalized? (Do Texas Hold 'Em and 5-card draw use the same ordering function?)
- The notion of "here's some invariants that I want to be true of all inputs", and trying to test as many interesting inputs as possible, is called _property-based testing_. I don't know what the frameworks for it in Rust are like; may be possible to use / repurpose some fuzz-testing ones?

This was a fun afternoon - thanks!