### PR TITLE
add the ability to deal cards face down

### DIFF
--- a/crates/cards/src/card.rs
+++ b/crates/cards/src/card.rs
@@ -6,12 +6,15 @@ use strum::EnumIter;
 /// Creates a new card.
 ///
 /// Requires the Rank and Suit to be provided as an ident.
+///
+/// Sets face_up to true by default.
 #[macro_export]
 macro_rules! card {
     ($rank:ident, $suit:ident) => {
         Card {
             rank: Rank::$rank,
             suit: Suit::$suit,
+            face_up: true,
         }
     };
 }
@@ -99,11 +102,16 @@ impl fmt::Display for Suit {
 pub struct Card {
     pub rank: Rank,
     pub suit: Suit,
+    pub face_up: bool,
 }
 
 impl Card {
     pub fn new(rank: Rank, suit: Suit) -> Self {
-        Self { rank, suit }
+        Self {
+            rank,
+            suit,
+            face_up: true,
+        }
     }
 
     pub fn value(&self) -> u8 {
@@ -147,7 +155,7 @@ impl PartialOrd for Card {
 
 impl fmt::Display for Card {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let card = match (self.rank, self.suit) {
+        let mut card = match (self.rank, self.suit) {
             (Rank::Two, Suit::Club) => '🃒',
             (Rank::Three, Suit::Club) => '🃓',
             (Rank::Four, Suit::Club) => '🃔',
@@ -201,6 +209,10 @@ impl fmt::Display for Card {
             (Rank::King, Suit::Spade) => '🂮',
             (Rank::Ace, Suit::Spade) => '🂡',
         };
+
+        if !self.face_up {
+            card = '🂠'
+        }
 
         write!(f, "{}", card)
     }

--- a/crates/cards/src/deck.rs
+++ b/crates/cards/src/deck.rs
@@ -34,8 +34,31 @@ impl Deck {
         self.cards.contains(card)
     }
 
+    /// Deals a card with the default face_up value.
     pub fn deal(&mut self) -> Option<Card> {
         if let Some(card) = self.cards.pop() {
+            Some(card)
+        } else {
+            eprintln!("Deck is empty.");
+            None
+        }
+    }
+
+    /// Deals a card face up with the Rank and Suit visible.
+    pub fn deal_face_up(&mut self) -> Option<Card> {
+        if let Some(mut card) = self.cards.pop() {
+            card.face_up = true;
+            Some(card)
+        } else {
+            eprintln!("Deck is empty.");
+            None
+        }
+    }
+
+    /// Deals a card face down with the Rank and Suit hidden.
+    pub fn deal_face_down(&mut self) -> Option<Card> {
+        if let Some(mut card) = self.cards.pop() {
+            card.face_up = false;
             Some(card)
         } else {
             eprintln!("Deck is empty.");

--- a/crates/poker/src/games/texas_hold_em.rs
+++ b/crates/poker/src/games/texas_hold_em.rs
@@ -241,7 +241,8 @@ impl TexasHoldEm {
 
     /// Deals a single card.
     fn deal_card(&mut self) -> Option<Card> {
-        if let Some(card) = self.deck.deal() {
+        // todo: change to deck.deal_face_down for all other players after testing is completed.
+        if let Some(card) = self.deck.deal_face_up() {
             return Some(card);
         }
 
@@ -278,7 +279,7 @@ impl TexasHoldEm {
         // Deal cards to player starting to the left of the dealer
         while current_player != dealer {
             if let Some(hand) = self.deal_hand() {
-                // todo: update to only show hand of user
+                // todo: Update to only show hand of user after testing is complete.
                 println!(
                     "Hand dealt to {}: {}",
                     self.seats[current_player].name,


### PR DESCRIPTION
New cards will be face up by default, but the deck implementation allows for dealing face up or face down.