### PR TITLE
Remove chips for small/big blinds & add chips to winning players' stacks

### DIFF
--- a/crates/poker/src/games/texas_hold_em.rs
+++ b/crates/poker/src/games/texas_hold_em.rs
@@ -20,16 +20,22 @@ pub struct TexasHoldEm {
     deck: Deck,
     players: HashSet<Player>,
     seats: Vec<Player>,
+    small_blind: u32,
+    big_blind: u32,
+    limit: bool,
 }
 
 impl TexasHoldEm {
     /// Create a new game that internally contains a deck and players.
-    pub fn new() -> Self {
+    pub fn new(small_blind: u32, big_blind: u32, limit: bool) -> Self {
         Self {
             game_over: false,
             deck: Deck::new(),
             players: HashSet::new(),
             seats: Vec::new(),
+            small_blind,
+            big_blind,
+            limit,
         }
     }
 

--- a/crates/poker/src/player.rs
+++ b/crates/poker/src/player.rs
@@ -29,7 +29,11 @@ impl Player {
         }
     }
 
-    pub fn update_chips(&mut self, chips: u32) {
+    pub fn add_chips(&mut self, chips: u32) {
         self.chips += chips;
+    }
+
+    pub fn subtract_chips(&mut self, chips: u32) {
+        self.chips -= chips;
     }
 }


### PR DESCRIPTION
## complete

- Implement adding/removing chips from players' stacks when posting blinds and winning the hand

## todo

- Allow players to place bets before, during, and after the flop, turn, and river
- Handle side pot logic
- Add limit/no-limit functionality