### PR TITLE
update repo path to reflect new crate name

### DIFF
--- a/crates/casino_cards/Cargo.toml
+++ b/crates/casino_cards/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MPL-2.0"
 description = "A library that provides a deck of playing cards that can be used for various card games."
 authors = ["Winston Cooke <contact@winstoncooke.com>"]
-repository = "https://github.com/winstonrc/casino/tree/main/crates/cards"
+repository = "https://github.com/winstonrc/casino/tree/main/crates/casino_cards"
 keywords = ["cards", "deck", "casino", "poker", "playing"]
 categories = ["game-development"]
 


### PR DESCRIPTION
The repo path broke after renaming the crate.