### PR TITLE
update version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "casino_games"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "casino_poker",
  "rand",

--- a/crates/casino_games/Cargo.toml
+++ b/crates/casino_games/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casino_games"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MPL-2.0"
 description = "Play casino games in your terminal."


### PR DESCRIPTION
- Perform major linting in [texas_hold_em_game.rs](https://github.com/winstonrc/casino/blob/main/crates/casino_games/src/texas_hold_em_game.rs)
- Improve the computer's decision making for betting to be _slightly_ more realistic
- Allow the player to enter `raise <amount>` to quickly raise rather than entering `raise` and then `10` separately (which still works)