### PR TITLE
Feat/seat view builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,5 +103,5 @@ jobs:
       - name: Install cargo-public-api
         run: cargo install cargo-public-api --version 0.52.0 --locked
 
-      - name: Check casino_poker 1.0 API snapshot
+      - name: Check casino_poker public API snapshot
         run: scripts/check-casino-poker-public-api.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Repository Notes For Coding Agents
+
+## Formatting
+
+- Always run `cargo fmt --all` before committing Rust changes
+- If you touch Markdown, also run Prettier on the touched Markdown files before the final diff
+- Do not assume `cargo fmt` formats docs, changelogs, README files, or workflow prose
+
+## Public API Snapshots
+
+- `casino_poker` public API changes must update `docs/public-api/casino_poker-1.0.txt`
+- Reproduce the CI gate with `scripts/check-casino-poker-public-api.sh`
+- If the snapshot diff is intentional, regenerate it with the same `cargo-public-api` output and include the snapshot update in the PR
+
+## PR Hygiene
+
+- Keep formatting-only churn separate from behavioral changes when practical
+- Run the exact failing CI script locally after fixing a CI-only failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ crate follows [Semantic Versioning](https://semver.org/).
 
 ---
 
-## Unreleased
+## 2026-06-16
 
-### casino_poker
+### casino_poker 1.0.1
 
 #### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ crate follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## Unreleased
+
+### casino_poker
+
+#### Added
+
+- `SeatView::builder()` so downstream agent tests can construct public seat
+  snapshots for `PlayerView::builder().seats(...)` without relying on struct
+  literals for a `#[non_exhaustive]` type.
+
+---
+
 ## 2026-06-15
 
 ### casino_poker 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ crate follows [Semantic Versioning](https://semver.org/).
 
 ## 2026-06-16
 
-### casino_poker 1.0.1
+### casino_poker 1.1.0
 
 #### Added
 
-- `SeatView::builder()` so downstream agent tests can construct public seat
+- `SeatView::builder()` so downstream consumers and agent tests can construct public seat
   snapshots for `PlayerView::builder().seats(...)` without relying on struct
   literals for a `#[non_exhaustive]` type.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,23 +45,57 @@ locally first avoids red builds and review round-trips.
 # 1. Format (CI runs this with --check and fails on any diff)
 cargo fmt --all
 
-# 2. Lint — warnings are treated as errors in CI. clippy is a full compile,
+# 2. Format any touched Markdown files with Prettier
+prettier --write <touched Markdown files>
+
+# 3. Lint — warnings are treated as errors in CI. clippy is a full compile,
 #    so it also catches anything a plain `cargo build`/`check` would.
 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
-# 3. Test
+# 4. Test
 cargo test --workspace --all-targets --locked
 
-# 4. Test documentation examples
+# 5. Test documentation examples
 cargo test --workspace --doc --locked
 
-# 5. Build strict public API documentation
+# 6. Build strict public API documentation
 RUSTDOCFLAGS="-D warnings -D missing_docs" cargo doc --workspace --no-deps --locked
 ```
 
 If `cargo fmt --all` changes any files, include those changes in the same
 commit. CI runs `cargo fmt --all --check`, which only _checks_ formatting and
 fails on any difference — it does not fix anything for you.
+
+`cargo fmt` does not format Markdown. When you edit Markdown, including
+`CHANGELOG.md`, `README.md`, crate READMEs, or docs under `docs/`, run Prettier
+on the touched files and include any formatting changes in the same commit.
+
+## Public API snapshots
+
+The `public_api` CI job compares the generated `casino_poker` public API against
+[`docs/public-api/casino_poker-1.0.txt`](docs/public-api/casino_poker-1.0.txt).
+Any intentional public API change must update that snapshot in the same PR.
+
+Reproduce the CI gate locally with:
+
+```sh
+scripts/check-casino-poker-public-api.sh
+```
+
+If the diff is expected, regenerate the snapshot with the pinned
+`cargo-public-api` output and commit the changed snapshot:
+
+```sh
+RUSTC_BOOTSTRAP=1 CARGO_TARGET_DIR=/tmp/casino-public-api-update \
+  cargo rustdoc --manifest-path "$PWD/Cargo.toml" -p casino_poker --locked --lib -- \
+  -Z unstable-options --output-format json
+
+cargo public-api \
+  --rustdoc-json /tmp/casino-public-api-update/doc/casino_poker.json \
+  -ss --color never > docs/public-api/casino_poker-1.0.txt
+
+scripts/check-casino-poker-public-api.sh
+```
 
 ## Commit messages
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "casino_poker"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "casino_cards",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "casino_poker"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "casino_cards",
  "criterion",

--- a/crates/casino_poker/Cargo.toml
+++ b/crates/casino_poker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casino_poker"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "MPL-2.0"
 readme = "README.md"

--- a/crates/casino_poker/Cargo.toml
+++ b/crates/casino_poker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casino_poker"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 license = "MPL-2.0"
 readme = "README.md"

--- a/crates/casino_poker/README.md
+++ b/crates/casino_poker/README.md
@@ -4,9 +4,9 @@
 
 A library that provides hand ranking & the backend for poker games. 
 
-**Note:** The public API follows [SemVer](https://semver.org/). Version `1.0.0`
-establishes the engine-owned hand lifecycle and checked, transactional state
-transitions as the stable API.
+**Note:** Since `1.0.0`, the public API follows [SemVer](https://semver.org/)
+around the engine-owned hand lifecycle and checked, transactional state
+transitions.
 
 ## Usage
 
@@ -148,9 +148,10 @@ stack/call sizes in big blinds — so a UI can render correct numbers without
 re-deriving them. `PlayerView` also carries `seats` (the public per-seat roster as
 `SeatView`s — id, stack, this-street commitment, fold/all-in status) and `button_seat`,
 so an agent sees the same objective table state a spectator does and can map a stored
-opponent model onto who is actually at the table. `PlayerView` is `#[non_exhaustive]`
-(the engine builds it; use `PlayerView::builder()` to construct one in your own agent
-tests), and both it and `HandMetrics` can gain fields in a minor release.
+opponent model onto who is actually at the table. `PlayerView` and `SeatView` are
+`#[non_exhaustive]`; use `PlayerView::builder()` and `SeatView::builder()` to
+construct them in your own agent tests. `PlayerView`, `SeatView`, and `HandMetrics`
+can gain fields in a minor release.
 
 ### Observing a hand
 

--- a/crates/casino_poker/src/games/texas_hold_em.rs
+++ b/crates/casino_poker/src/games/texas_hold_em.rs
@@ -357,6 +357,78 @@ pub struct SeatView {
     pub all_in: bool,
 }
 
+impl SeatView {
+    /// Start building a `SeatView` outside the engine, e.g. for an agent unit test
+    /// that needs a complete [`PlayerView`].
+    pub fn builder() -> SeatViewBuilder {
+        SeatViewBuilder {
+            view: SeatView {
+                id: Uuid::nil(),
+                name: String::new(),
+                chips: 0,
+                committed_this_street: 0,
+                contributed_this_hand: 0,
+                folded: false,
+                all_in: false,
+            },
+        }
+    }
+}
+
+/// Builder for [`SeatView`], which is `#[non_exhaustive]`.
+pub struct SeatViewBuilder {
+    view: SeatView,
+}
+
+impl SeatViewBuilder {
+    /// Finish building the [`SeatView`].
+    pub fn build(self) -> SeatView {
+        self.view
+    }
+
+    /// Set the stable player identity.
+    pub fn id(mut self, id: Uuid) -> Self {
+        self.view.id = id;
+        self
+    }
+
+    /// Set the display name.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.view.name = name.into();
+        self
+    }
+
+    /// Set the chips remaining in the stack.
+    pub fn chips(mut self, chips: u32) -> Self {
+        self.view.chips = chips;
+        self
+    }
+
+    /// Set chips committed on the current street.
+    pub fn committed_this_street(mut self, committed_this_street: u32) -> Self {
+        self.view.committed_this_street = committed_this_street;
+        self
+    }
+
+    /// Set cumulative chips contributed across the current hand.
+    pub fn contributed_this_hand(mut self, contributed_this_hand: u32) -> Self {
+        self.view.contributed_this_hand = contributed_this_hand;
+        self
+    }
+
+    /// Set whether the player has folded this hand.
+    pub fn folded(mut self, folded: bool) -> Self {
+        self.view.folded = folded;
+        self
+    }
+
+    /// Set whether the player has committed their entire stack.
+    pub fn all_in(mut self, all_in: bool) -> Self {
+        self.view.all_in = all_in;
+        self
+    }
+}
+
 /// Everything **one** player's client needs to render and (re)join a game: the
 /// public [`TableView`], that player's own private state, and the hand's narration
 /// so far. Produced by [`TexasHoldEm::client_view`].

--- a/crates/casino_poker/src/games/texas_hold_em.rs
+++ b/crates/casino_poker/src/games/texas_hold_em.rs
@@ -3445,6 +3445,37 @@ mod tests {
     }
 
     #[test]
+    fn seat_view_builder_sets_every_public_field() {
+        let id = Uuid::from_u128(42);
+        let default = SeatView::builder().build();
+        assert_eq!(default.id, Uuid::nil());
+        assert_eq!(default.name, "");
+        assert_eq!(default.chips, 0);
+        assert_eq!(default.committed_this_street, 0);
+        assert_eq!(default.contributed_this_hand, 0);
+        assert!(!default.folded);
+        assert!(!default.all_in);
+
+        let seat = SeatView::builder()
+            .id(id)
+            .name("Ada")
+            .chips(90)
+            .committed_this_street(10)
+            .contributed_this_hand(35)
+            .folded(true)
+            .all_in(true)
+            .build();
+
+        assert_eq!(seat.id, id);
+        assert_eq!(seat.name, "Ada");
+        assert_eq!(seat.chips, 90);
+        assert_eq!(seat.committed_this_street, 10);
+        assert_eq!(seat.contributed_this_hand, 35);
+        assert!(seat.folded);
+        assert!(seat.all_in);
+    }
+
+    #[test]
     fn seat_view_contributed_this_hand_accumulates_across_streets() {
         // `contributed_this_hand` is the seat's running stake in the live pot; it
         // must grow across streets, while `committed_this_street` resets each street.

--- a/crates/casino_poker/tests/downstream_api.rs
+++ b/crates/casino_poker/tests/downstream_api.rs
@@ -1,7 +1,9 @@
 use casino_poker::agent::{AgentError, PlayerView, PokerAgent};
 use casino_poker::betting::PlayerAction;
 use casino_poker::casino_cards::card::{Card, Rank, Suit};
+use casino_poker::games::texas_hold_em::SeatView;
 use casino_poker::hand_rankings::{evaluate_holdem, EvaluatedHand, HandCategory};
+use casino_poker::uuid::Uuid;
 
 struct ExternalAgent;
 
@@ -52,4 +54,39 @@ fn external_consumers_can_evaluate_serialize_and_implement_agents() {
     assert_eq!(classify_agent_error(&error), "failure");
     assert_eq!(error.to_string(), "provider unavailable");
     let _: &dyn std::error::Error = &error;
+}
+
+#[test]
+fn external_consumers_can_build_seat_views_for_player_view_tests() {
+    let hero = Uuid::from_u128(1);
+    let villain = Uuid::from_u128(2);
+    let seats = vec![
+        SeatView::builder()
+            .id(hero)
+            .name("Hero")
+            .chips(98)
+            .committed_this_street(2)
+            .contributed_this_hand(2)
+            .build(),
+        SeatView::builder()
+            .id(villain)
+            .name("Villain")
+            .chips(100)
+            .folded(false)
+            .all_in(false)
+            .build(),
+    ];
+
+    let view = PlayerView::builder()
+        .you(hero)
+        .name("Hero")
+        .players_remaining(2)
+        .seats(seats)
+        .button_seat(Some(0))
+        .build();
+
+    assert_eq!(view.seats.len(), 2);
+    assert_eq!(view.seats[0].id, hero);
+    assert_eq!(view.seats[0].committed_this_street, 2);
+    assert_eq!(view.seats[1].name, "Villain");
 }

--- a/crates/casino_poker/tests/downstream_api.rs
+++ b/crates/casino_poker/tests/downstream_api.rs
@@ -72,8 +72,9 @@ fn external_consumers_can_build_seat_views_for_player_view_tests() {
             .id(villain)
             .name("Villain")
             .chips(100)
-            .folded(false)
-            .all_in(false)
+            .contributed_this_hand(4)
+            .folded(true)
+            .all_in(true)
             .build(),
     ];
 
@@ -86,7 +87,19 @@ fn external_consumers_can_build_seat_views_for_player_view_tests() {
         .build();
 
     assert_eq!(view.seats.len(), 2);
+    assert_eq!(view.button_seat, Some(0));
     assert_eq!(view.seats[0].id, hero);
+    assert_eq!(view.seats[0].name, "Hero");
+    assert_eq!(view.seats[0].chips, 98);
     assert_eq!(view.seats[0].committed_this_street, 2);
+    assert_eq!(view.seats[0].contributed_this_hand, 2);
+    assert!(!view.seats[0].folded);
+    assert!(!view.seats[0].all_in);
+    assert_eq!(view.seats[1].id, villain);
     assert_eq!(view.seats[1].name, "Villain");
+    assert_eq!(view.seats[1].chips, 100);
+    assert_eq!(view.seats[1].committed_this_street, 0);
+    assert_eq!(view.seats[1].contributed_this_hand, 4);
+    assert!(view.seats[1].folded);
+    assert!(view.seats[1].all_in);
 }

--- a/docs/public-api/README.md
+++ b/docs/public-api/README.md
@@ -1,8 +1,8 @@
-# casino_poker 1.0 Public API
+# casino_poker Public API
 
-This document records the public API decisions for the `casino_poker` 1.0.0
-release. It describes the final supported surface rather than earlier
-pre-release proposals.
+This document records the public API decisions for the stable `casino_poker`
+line. The compatibility snapshot began with the `1.0.0` release and now acts as
+the review gate for intentional public API changes.
 
 ## Supported Surface
 
@@ -20,8 +20,8 @@ pre-release proposals.
 - `casino_cards` and `uuid` are re-exported so consumers can use the exact types
   carried by the API.
 
-`TexasHoldEm` remains directly serializable for 1.0. Restored state is validated
-before transitions or awards proceed. Nonblocking transitions are the preferred
+`TexasHoldEm` remains directly serializable. Restored state is validated before
+transitions or awards proceed. Nonblocking transitions are the preferred
 integration for servers and asynchronous applications; the blocking wrappers
 remain supported for terminal games and simulations.
 
@@ -80,10 +80,10 @@ older infallible return-value benchmarks.
 ## Compatibility Gate
 
 [`casino_poker-1.0.txt`](casino_poker-1.0.txt) is the simplified
-`cargo-public-api 0.52.0` snapshot for the supported 1.0 surface, generated with
-Rust 1.96.0. CI regenerates the same representation and rejects any difference,
-including changes to derived trait implementations. Intentional API changes
-therefore require an explicit snapshot review and update.
+`cargo-public-api 0.52.0` snapshot for the stable public API surface, generated
+with Rust 1.96.0. CI regenerates the same representation and rejects any
+difference, including changes to derived trait implementations. Intentional API
+changes therefore require an explicit snapshot review and update.
 
 Run the gate locally after changing `casino_poker` public API:
 

--- a/docs/public-api/casino_poker-1.0-review.md
+++ b/docs/public-api/casino_poker-1.0-review.md
@@ -66,12 +66,12 @@ Criterion 0.8.2 produced these approximate local release-mode medians after the
 checked, allocation-free evaluator redesign. They were measured on Linux
 `x86_64`, an AMD Ryzen 5 7600X, and Rust 1.96.0:
 
-| Public workload | Median |
-| --- | ---: |
-| `evaluate_five` | 16.28 ns |
+| Public workload                    |    Median |
+| ---------------------------------- | --------: |
+| `evaluate_five`                    |  16.28 ns |
 | `evaluate_holdem` with seven cards | 381.97 ns |
-| `evaluate_omaha` with nine cards | 935.75 ns |
-| Nine-player Hold'em showdown | 3.64 us |
+| `evaluate_omaha` with nine cards   | 935.75 ns |
+| Nine-player Hold'em showdown       |   3.64 us |
 
 These are local reference values, not portable CI thresholds. They establish a
 new baseline for the fallible APIs and should not be compared directly with the
@@ -84,6 +84,16 @@ older infallible return-value benchmarks.
 Rust 1.96.0. CI regenerates the same representation and rejects any difference,
 including changes to derived trait implementations. Intentional API changes
 therefore require an explicit snapshot review and update.
+
+Run the gate locally after changing `casino_poker` public API:
+
+```sh
+scripts/check-casino-poker-public-api.sh
+```
+
+If the diff is intentional, regenerate the snapshot with the pinned
+`cargo-public-api` output and commit the updated
+[`casino_poker-1.0.txt`](casino_poker-1.0.txt) in the same PR.
 
 `casino_poker` depends on `casino_cards = "2"`, so `casino_cards 2.0.0` must be
 published before the final `cargo package` verification and `casino_poker`

--- a/docs/public-api/casino_poker-1.0.txt
+++ b/docs/public-api/casino_poker-1.0.txt
@@ -580,6 +580,8 @@ pub casino_poker::games::texas_hold_em::SeatView::contributed_this_hand: u32
 pub casino_poker::games::texas_hold_em::SeatView::folded: bool
 pub casino_poker::games::texas_hold_em::SeatView::id: uuid::Uuid
 pub casino_poker::games::texas_hold_em::SeatView::name: alloc::string::String
+impl casino_poker::games::texas_hold_em::SeatView
+pub fn casino_poker::games::texas_hold_em::SeatView::builder() -> casino_poker::games::texas_hold_em::SeatViewBuilder
 impl core::clone::Clone for casino_poker::games::texas_hold_em::SeatView
 pub fn casino_poker::games::texas_hold_em::SeatView::clone(&self) -> casino_poker::games::texas_hold_em::SeatView
 impl core::fmt::Debug for casino_poker::games::texas_hold_em::SeatView
@@ -588,6 +590,16 @@ impl serde_core::ser::Serialize for casino_poker::games::texas_hold_em::SeatView
 pub fn casino_poker::games::texas_hold_em::SeatView::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for casino_poker::games::texas_hold_em::SeatView
 pub fn casino_poker::games::texas_hold_em::SeatView::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+pub struct casino_poker::games::texas_hold_em::SeatViewBuilder
+impl casino_poker::games::texas_hold_em::SeatViewBuilder
+pub fn casino_poker::games::texas_hold_em::SeatViewBuilder::all_in(self, bool) -> Self
+pub fn casino_poker::games::texas_hold_em::SeatViewBuilder::build(self) -> casino_poker::games::texas_hold_em::SeatView
+pub fn casino_poker::games::texas_hold_em::SeatViewBuilder::chips(self, u32) -> Self
+pub fn casino_poker::games::texas_hold_em::SeatViewBuilder::committed_this_street(self, u32) -> Self
+pub fn casino_poker::games::texas_hold_em::SeatViewBuilder::contributed_this_hand(self, u32) -> Self
+pub fn casino_poker::games::texas_hold_em::SeatViewBuilder::folded(self, bool) -> Self
+pub fn casino_poker::games::texas_hold_em::SeatViewBuilder::id(self, uuid::Uuid) -> Self
+pub fn casino_poker::games::texas_hold_em::SeatViewBuilder::name(self, impl core::convert::Into<alloc::string::String>) -> Self
 #[non_exhaustive] pub struct casino_poker::games::texas_hold_em::TableView
 pub casino_poker::games::texas_hold_em::TableView::board: alloc::vec::Vec<casino_cards::card::Card>
 pub casino_poker::games::texas_hold_em::TableView::button_seat: core::option::Option<usize>


### PR DESCRIPTION
# Contents

- Add SeatView builder for downstream tests
- Prepare casino_poker 1.0.1
- Use minor version for SeatView builder release
- Strengthen SeatView downstream API test
- Update casino_poker public API snapshot
- Document formatting and API snapshot checks
- Rename public API review doc