### PR TITLE
feat: add texas hold'em hand progress stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ crate follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## 2026-06-24
+
+### casino_poker 1.2.0
+
+#### Added
+
+- Fine-grained hand progression through `HandEventCursor`,
+  `drive_hand_progress`, `HandProgressStep::Event`, and
+  `submit_hand_progress_action`, allowing downstream consumers to drain one
+  public/redacted event at a time while keeping a durable external event cursor.
+- Public-safe action prompts through `HandProgressStep::AwaitingPlayer`, which
+  exposes only the acting player and `DecisionId`. Retrieve the private
+  `PendingAction` prompt through `pending_action()` or
+  `client_view(player_id)` so shared event streams cannot leak hidden
+  information.
+
+---
+
 ## 2026-06-16
 
 ### casino_poker 1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ crate follows [Semantic Versioning](https://semver.org/).
   `drive_hand_progress`, `HandProgressStep::Event`, and
   `submit_hand_progress_action`, allowing downstream consumers to drain one
   public/redacted event at a time while keeping a durable external event cursor.
+- `GameEvent::HoleCardsExposed`, emitted when all remaining live players are
+  committed to showdown before the board has fully run out. It reveals only hole
+  cards, not final hand strength, so UIs can show exposed hands at the real
+  all-in moment without spoiling future board cards.
 - Public-safe action prompts through `HandProgressStep::AwaitingPlayer`, which
   exposes only the acting player and `DecisionId`. Retrieve the private
   `PendingAction` prompt through `pending_action()` or

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "casino_poker"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "casino_cards",
  "criterion",

--- a/crates/casino_poker/Cargo.toml
+++ b/crates/casino_poker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casino_poker"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "MPL-2.0"
 readme = "README.md"

--- a/crates/casino_poker/README.md
+++ b/crates/casino_poker/README.md
@@ -192,6 +192,10 @@ Hidden-information rule of thumb: `HandProgressStep::Event`, `table()`, and
 `public_events()` are suitable for shared streams. `PendingAction` and the
 `pending_action` field inside `ClientView` contain the actor's private decision
 context, including their hole cards, and should only be delivered to that player.
+When all remaining live players are all-in before the board is complete, the
+progress stream emits `HoleCardsExposed` before the remaining `StreetDealt`
+events. That event carries only public hole cards; final made-hand values remain
+reserved for `ShowdownReveal` after the full board is known.
 
 For **save/resume and reconnection**, `TexasHoldEm` is `serde`-serializable: persist
 it mid-hand and restore it to continue from the exact spot (re-attach an observer
@@ -245,14 +249,18 @@ impl GameObserver for Printer {
 Notable events:
 
 - Player-bearing events (`BlindPosted`, `ActionTaken`, `UncalledBetReturned`,
-  `ShowdownReveal`, `PotAwarded`) identify the player by a `PlayerRef` (stable `id` +
-  `name`); `PlayerRef` renders as its name, so it interpolates directly in display.
+  `HoleCardsExposed`, `ShowdownReveal`, `PotAwarded`) identify the player by a
+  `PlayerRef` (stable `id` + `name`); `PlayerRef` renders as its name, so it
+  interpolates directly in display.
 - `HandStarted` carries the seat roster (`SeatInfo` with a `PlayerRef` + starting
   stack), the button seat, and the blinds — the data a hand-history header needs.
 - `HoleCardsDealt` marks the start of betting; its `hero` field carries the
   perspective player (`PlayerRef`) and cards (when a hero is set), else `None`.
 - `ActionTaken` carries the `Street` and an `ActionView`; `Raised { by, to }`
   gives both the raise increment and the new total (PokerStars "raises by to to").
+- `HoleCardsExposed` carries a live player's `hole` cards once betting is locked
+  and all remaining players are committed to showdown. It intentionally does not
+  include a final hand value, because more board cards may still be coming.
 - `Showdown` is emitted once before the reveals when two or more players reach a
   showdown, carrying the final `board` and `pot`.
 - `ShowdownReveal` carries the player's `hole` cards and their `hand` (a

--- a/crates/casino_poker/README.md
+++ b/crates/casino_poker/README.md
@@ -126,6 +126,64 @@ The same identified submission contract exists one street down through
 `abort_betting_round()` refunds its contributions, returns its cards to the deck,
 and leaves the table ready for a new hand without emitting `HandComplete`.
 
+When a UI or network server needs each public event separately, use the
+fine-grained progress API. `HandEventCursor` is serializable and lives outside the
+engine, so you can persist it beside `TexasHoldEm`. `drive_hand_progress` yields
+`HandProgressStep::Event` for one public/redacted event at a time. When it yields
+`AwaitingPlayer`, that value is safe to broadcast because it carries only the
+acting player and `DecisionId`; it deliberately does not include the private
+`PlayerView`.
+
+Fetch the private prompt only for the actor with `pending_action()` or
+`client_view(player_id)`, then submit through `submit_hand_progress_action`:
+
+```rust
+use casino_poker::agent::LegalAction;
+use casino_poker::betting::PlayerAction;
+use casino_poker::games::texas_hold_em::{HandEventCursor, HandProgressStep, TexasHoldEm};
+
+fn choose_action(legal_actions: &[LegalAction]) -> PlayerAction {
+    if legal_actions.iter().any(|a| matches!(a, LegalAction::Check)) {
+        PlayerAction::Check
+    } else if legal_actions.iter().any(|a| matches!(a, LegalAction::Call(_))) {
+        PlayerAction::Call
+    } else {
+        PlayerAction::Fold
+    }
+}
+
+fn drive_public_progress(game: &mut TexasHoldEm, cursor: &mut HandEventCursor) {
+    let mut step = game.drive_hand_progress(cursor);
+    loop {
+        match step {
+            HandProgressStep::Event(event) => {
+                // Broadcast or persist `event`; it is redacted like `public_events()`.
+                step = game.drive_hand_progress(cursor);
+            }
+            HandProgressStep::AwaitingPlayer { player, decision_id } => {
+                // Private: send only to `player`, never to the whole table.
+                let pending = game
+                    .client_view(player)
+                    .pending_action
+                    .expect("the actor can see their own pending prompt");
+                let action = choose_action(&pending.view.legal_actions);
+
+                step = game
+                    .submit_hand_progress_action(cursor, player, decision_id, action)
+                    .expect("the decision is still current");
+            }
+            HandProgressStep::HandComplete | HandProgressStep::CannotStart(_) => return,
+            _ => return,
+        }
+    }
+}
+```
+
+Hidden-information rule of thumb: `HandProgressStep::Event`, `table()`, and
+`public_events()` are suitable for shared streams. `PendingAction` and the
+`pending_action` field inside `ClientView` contain the actor's private decision
+context, including their hole cards, and should only be delivered to that player.
+
 For **save/resume and reconnection**, `TexasHoldEm` is `serde`-serializable: persist
 it mid-hand and restore it to continue from the exact spot (re-attach an observer
 with `set_observer`, then `replay_log()` to re-narrate the hand so far). For a

--- a/crates/casino_poker/README.md
+++ b/crates/casino_poker/README.md
@@ -128,7 +128,10 @@ and leaves the table ready for a new hand without emitting `HandComplete`.
 
 When a UI or network server needs each public event separately, use the
 fine-grained progress API. `HandEventCursor` is serializable and lives outside the
-engine, so you can persist it beside `TexasHoldEm`. `drive_hand_progress` yields
+engine, so you can persist it beside `TexasHoldEm`. If you store cursor fields
+instead of serializing the cursor directly, persist `hand_number()`,
+`next_event()`, and `terminal_reported()`, then rebuild with
+`HandEventCursor::from_parts`. `drive_hand_progress` yields
 `HandProgressStep::Event` for one public/redacted event at a time. When it yields
 `AwaitingPlayer`, that value is safe to broadcast because it carries only the
 acting player and `DecisionId`; it deliberately does not include the private
@@ -140,6 +143,7 @@ Fetch the private prompt only for the actor with `pending_action()` or
 ```rust
 use casino_poker::agent::LegalAction;
 use casino_poker::betting::PlayerAction;
+use casino_poker::events::GameEvent;
 use casino_poker::games::texas_hold_em::{HandEventCursor, HandProgressStep, TexasHoldEm};
 
 fn choose_action(legal_actions: &[LegalAction]) -> PlayerAction {
@@ -157,8 +161,13 @@ fn drive_public_progress(game: &mut TexasHoldEm, cursor: &mut HandEventCursor) {
     loop {
         match step {
             HandProgressStep::Event(event) => {
+                let hand_complete = matches!(event, GameEvent::HandComplete);
                 // Broadcast or persist `event`; it is redacted like `public_events()`.
                 step = game.drive_hand_progress(cursor);
+                if hand_complete {
+                    assert!(matches!(step, HandProgressStep::HandComplete));
+                    return;
+                }
             }
             HandProgressStep::AwaitingPlayer { player, decision_id } => {
                 // Private: send only to `player`, never to the whole table.

--- a/crates/casino_poker/README.md
+++ b/crates/casino_poker/README.md
@@ -192,10 +192,11 @@ Hidden-information rule of thumb: `HandProgressStep::Event`, `table()`, and
 `public_events()` are suitable for shared streams. `PendingAction` and the
 `pending_action` field inside `ClientView` contain the actor's private decision
 context, including their hole cards, and should only be delivered to that player.
-When all remaining live players are all-in before the board is complete, the
-progress stream emits `HoleCardsExposed` before the remaining `StreetDealt`
-events. That event carries only public hole cards; final made-hand values remain
-reserved for `ShowdownReveal` after the full board is known.
+When betting is locked before the board is complete and all remaining live
+players are committed to showdown, the progress stream emits
+`HoleCardsExposed` before the remaining `StreetDealt` events. That event carries
+only public hole cards; final made-hand values remain reserved for
+`ShowdownReveal` after the full board is known.
 
 For **save/resume and reconnection**, `TexasHoldEm` is `serde`-serializable: persist
 it mid-hand and restore it to continue from the exact spot (re-attach an observer

--- a/crates/casino_poker/src/events.rs
+++ b/crates/casino_poker/src/events.rs
@@ -154,6 +154,16 @@ pub enum GameEvent {
         /// Chips returned.
         amount: u32,
     },
+    /// A live player's hole cards were exposed because betting is locked and the
+    /// remaining players are committed to showdown. This can happen before the
+    /// remaining board cards are dealt, so it intentionally carries no final hand
+    /// value.
+    HoleCardsExposed {
+        /// Player exposing their hand.
+        player: PlayerRef,
+        /// The player's two hole cards.
+        hole: Vec<Card>,
+    },
     /// Two or more players reached a showdown. Emitted once, after the final
     /// betting round and before any [`ShowdownReveal`](GameEvent::ShowdownReveal),
     /// carrying the final board and pot so a front-end can re-show the table the
@@ -346,6 +356,13 @@ mod tests {
                     to: 10,
                     all_in: true,
                 },
+            },
+            GameEvent::HoleCardsExposed {
+                player: pref("Bob"),
+                hole: vec![
+                    Card::new(Rank::Ace, Suit::Spade),
+                    Card::new(Rank::King, Suit::Heart),
+                ],
             },
             GameEvent::Showdown {
                 board: vec![

--- a/crates/casino_poker/src/games/texas_hold_em.rs
+++ b/crates/casino_poker/src/games/texas_hold_em.rs
@@ -291,6 +291,9 @@ pub struct HandEventCursor {
     hand_number: Option<u32>,
     /// Index of the next event to yield from the current hand's event log.
     next_event: u64,
+    /// Whether the terminal hand-complete boundary has already been yielded.
+    #[serde(default)]
+    terminal_reported: bool,
 }
 
 impl Default for HandEventCursor {
@@ -305,14 +308,16 @@ impl HandEventCursor {
         Self {
             hand_number: None,
             next_event: 0,
+            terminal_reported: false,
         }
     }
 
     /// Rebuild a cursor from durable parts.
-    pub fn from_parts(hand_number: Option<u32>, next_event: u64) -> Self {
+    pub fn from_parts(hand_number: Option<u32>, next_event: u64, terminal_reported: bool) -> Self {
         Self {
             hand_number,
             next_event,
+            terminal_reported,
         }
     }
 
@@ -324,6 +329,11 @@ impl HandEventCursor {
     /// Durable event offset within the current hand's event log.
     pub fn next_event(&self) -> u64 {
         self.next_event
+    }
+
+    /// Whether the terminal hand-complete boundary has already been yielded.
+    pub fn terminal_reported(&self) -> bool {
+        self.terminal_reported
     }
 }
 
@@ -770,17 +780,34 @@ impl TexasHoldEm {
         if cursor.hand_number != hand_number {
             cursor.hand_number = hand_number;
             cursor.next_event = 0;
+            cursor.terminal_reported = false;
         }
         let index = match usize::try_from(cursor.next_event) {
             Ok(index) if index <= self.event_log.len() => index,
             _ => {
                 cursor.next_event = 0;
+                cursor.terminal_reported = false;
                 0
             }
         };
         let event = self.public_event_at(index)?;
         cursor.next_event += 1;
+        cursor.terminal_reported = false;
         Some(event)
+    }
+
+    fn terminal_progress_step(&self, cursor: &mut HandEventCursor) -> Option<HandProgressStep> {
+        let hand_number = self.current_progress_hand_number()?;
+        if cursor.hand_number != Some(hand_number)
+            || cursor.terminal_reported
+            || self.hand_in_progress()
+            || !matches!(self.event_log.last(), Some(GameEvent::HandComplete))
+            || cursor.next_event != u64::try_from(self.event_log.len()).unwrap_or(u64::MAX)
+        {
+            return None;
+        }
+        cursor.terminal_reported = true;
+        Some(HandProgressStep::HandComplete)
     }
 
     /// Create a new player with zero chips.
@@ -1689,6 +1716,7 @@ impl TexasHoldEm {
         HandEventCursor::from_parts(
             self.current_progress_hand_number(),
             u64::try_from(self.event_log.len()).unwrap_or(u64::MAX),
+            false,
         )
     }
 
@@ -1700,17 +1728,24 @@ impl TexasHoldEm {
     /// [`client_view`](Self::client_view) to retrieve the private prompt. This
     /// method does not replay the log or notify observers itself, so it does not
     /// duplicate observer notifications emitted by normal engine advancement.
-    /// After the final public
-    /// [`GameEvent::HandComplete`] event has been drained, the next call follows
-    /// [`drive_hand`](Self::drive_hand) by starting a fresh hand when possible.
+    /// After the final public [`GameEvent::HandComplete`] event has been drained,
+    /// the next call returns [`HandProgressStep::HandComplete`]. A subsequent call
+    /// follows [`drive_hand`](Self::drive_hand) by starting a fresh hand when
+    /// possible.
     pub fn drive_hand_progress(&mut self, cursor: &mut HandEventCursor) -> HandProgressStep {
         if let Some(event) = self.next_progress_event(cursor) {
             return HandProgressStep::Event(event);
+        }
+        if let Some(step) = self.terminal_progress_step(cursor) {
+            return step;
         }
 
         let step = self.drive_hand();
         if let Some(event) = self.next_progress_event(cursor) {
             return HandProgressStep::Event(event);
+        }
+        if let Some(step) = self.terminal_progress_step(cursor) {
+            return step;
         }
         step.into()
     }
@@ -1736,15 +1771,62 @@ impl TexasHoldEm {
         Ok(self.drive_hand_from(street, step))
     }
 
+    fn validate_action_submission(
+        &self,
+        player: Uuid,
+        decision_id: DecisionId,
+        action: PlayerAction,
+    ) -> Result<(), ActionSubmissionError> {
+        self.validate_roster_and_bankroll()
+            .map_err(ActionSubmissionError::InvalidState)?;
+        let active = self
+            .betting
+            .as_ref()
+            .ok_or(ActionSubmissionError::NoActionPending)?;
+        let (expected_player, expected_decision) = active
+            .awaiting
+            .ok_or(ActionSubmissionError::NoActionPending)?;
+        if decision_id != expected_decision {
+            return Err(ActionSubmissionError::StaleDecision {
+                expected: expected_decision,
+                submitted: decision_id,
+            });
+        }
+        if player != expected_player {
+            return Err(ActionSubmissionError::WrongPlayer {
+                expected: expected_player,
+                submitted: player,
+            });
+        }
+
+        let chips = self.players.get(&player).map_or(0, |p| p.chips);
+        let resolved = resolve_action(
+            action,
+            chips,
+            active.round.committed(player),
+            active.round.current_bet,
+            active.round.last_raise_increment,
+        )
+        .map_err(ActionSubmissionError::IllegalAction)?;
+        if resolved.raised_to.is_some() && !active.round.may_raise(player) {
+            return Err(ActionSubmissionError::IllegalAction(
+                ActionError::RaiseNotAllowed,
+            ));
+        }
+        Ok(())
+    }
+
     /// Submit an action for a pending [`HandProgressStep::AwaitingPlayer`] and
     /// return the next progression item.
     ///
-    /// If `cursor` still has an undrained public event, this returns that event
-    /// without applying the action. Callers should drain it first, then resubmit
-    /// the same player, decision identity, and action. This keeps public events
-    /// ordered before any mutation caused by the action. Returned `Event`
-    /// payloads are public/redacted. A returned `AwaitingPlayer` identifies the
-    /// next acting player without exposing their private prompt.
+    /// The submitted player, decision identity, and action are validated before
+    /// any mutation or event drainage. If `cursor` still has an undrained public
+    /// event, a valid submission returns that event without applying the action.
+    /// Callers should drain it first, then resubmit the same player, decision
+    /// identity, and action. This keeps public events ordered before any mutation
+    /// caused by the action. Returned `Event` payloads are public/redacted. A
+    /// returned `AwaitingPlayer` identifies the next acting player without
+    /// exposing their private prompt.
     pub fn submit_hand_progress_action(
         &mut self,
         cursor: &mut HandEventCursor,
@@ -1752,6 +1834,7 @@ impl TexasHoldEm {
         decision_id: DecisionId,
         action: PlayerAction,
     ) -> Result<HandProgressStep, ActionSubmissionError> {
+        self.validate_action_submission(player, decision_id, action)?;
         if let Some(event) = self.next_progress_event(cursor) {
             return Ok(HandProgressStep::Event(event));
         }
@@ -4181,7 +4264,7 @@ mod tests {
     }
 
     #[test]
-    fn hand_progress_starts_next_hand_after_final_event_is_drained() {
+    fn hand_progress_reports_terminal_step_after_final_event_is_drained() {
         let mut game = TexasHoldEm::new_seeded(0, 10, 1, 2, 31);
         seat_players(&mut game, &[100, 100, 100]);
         let mut cursor = HandEventCursor::default();
@@ -4233,6 +4316,11 @@ mod tests {
         }
 
         assert!(!game.hand_in_progress(), "first hand is fully resolved");
+
+        assert!(matches!(
+            game.drive_hand_progress(&mut cursor),
+            HandProgressStep::HandComplete
+        ));
 
         match game.drive_hand_progress(&mut cursor) {
             HandProgressStep::Event(GameEvent::HandStarted { hand_number, .. }) => {
@@ -4346,12 +4434,62 @@ mod tests {
 
     #[test]
     fn hand_progress_cursor_round_trips_through_json() {
-        let cursor = HandEventCursor::from_parts(Some(3), 7);
+        let cursor = HandEventCursor::from_parts(Some(3), 7, true);
         let json = serde_json::to_string(&cursor).unwrap();
         let restored: HandEventCursor = serde_json::from_str(&json).unwrap();
         assert_eq!(restored, cursor);
         assert_eq!(restored.hand_number(), Some(3));
         assert_eq!(restored.next_event(), 7);
+        assert!(restored.terminal_reported());
+    }
+
+    #[test]
+    fn hand_progress_cursor_parts_preserve_terminal_boundary() {
+        let mut game = TexasHoldEm::new_seeded(0, 10, 1, 2, 31);
+        seat_players(&mut game, &[100, 100, 100]);
+        let mut cursor = HandEventCursor::default();
+        let mut first_hand_number = None;
+
+        loop {
+            match game.drive_hand_progress(&mut cursor) {
+                HandProgressStep::Event(GameEvent::HandStarted { hand_number, .. }) => {
+                    first_hand_number = Some(hand_number);
+                }
+                HandProgressStep::Event(GameEvent::HandComplete) => {
+                    break;
+                }
+                HandProgressStep::Event(_) => {}
+                HandProgressStep::AwaitingPlayer {
+                    player,
+                    decision_id,
+                } => {
+                    let pending = game.pending_action().unwrap();
+                    let action = ShoveAgent.decide(&pending.view).unwrap();
+                    game.submit_hand_progress_action(&mut cursor, player, decision_id, action)
+                        .unwrap();
+                }
+                HandProgressStep::HandComplete => panic!("terminal step precedes final event"),
+                HandProgressStep::CannotStart(error) => panic!("hand should start: {error}"),
+            }
+        }
+        assert!(matches!(
+            game.drive_hand_progress(&mut cursor),
+            HandProgressStep::HandComplete
+        ));
+        assert!(cursor.terminal_reported());
+
+        let mut rebuilt = HandEventCursor::from_parts(
+            cursor.hand_number(),
+            cursor.next_event(),
+            cursor.terminal_reported(),
+        );
+        let first_hand_number = first_hand_number.expect("hand start was yielded");
+        match game.drive_hand_progress(&mut rebuilt) {
+            HandProgressStep::Event(GameEvent::HandStarted { hand_number, .. }) => {
+                assert_eq!(hand_number, first_hand_number + 1);
+            }
+            other => panic!("rebuilt cursor should advance to next hand, got {other:?}"),
+        }
     }
 
     #[test]
@@ -4438,6 +4576,41 @@ mod tests {
             "action is not applied until earlier events are drained"
         );
         assert!(game.pending_action().is_some());
+    }
+
+    #[test]
+    fn submit_hand_progress_action_validates_before_draining_pending_event() {
+        let mut game = TexasHoldEm::new_seeded(0, 10, 1, 2, 29);
+        let ids = seat_players(&mut game, &[100, 100]);
+        let mut cursor = HandEventCursor::default();
+        let HandStep::AwaitingAction(pending) = game.drive_hand() else {
+            panic!("expected a pending action");
+        };
+        let other = *ids.iter().find(|&&id| id != pending.player).unwrap();
+
+        let before = serde_json::to_string(&game).unwrap();
+        let error = game
+            .submit_hand_progress_action(
+                &mut cursor,
+                other,
+                pending.decision_id,
+                PlayerAction::Call,
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ActionSubmissionError::WrongPlayer {
+                expected,
+                submitted
+            } if expected == pending.player && submitted == other
+        ));
+        assert_eq!(cursor.next_event(), 0, "lagging cursor was not drained");
+        assert_eq!(
+            serde_json::to_string(&game).unwrap(),
+            before,
+            "invalid submission is rejected without mutation"
+        );
     }
 
     #[test]

--- a/crates/casino_poker/src/games/texas_hold_em.rs
+++ b/crates/casino_poker/src/games/texas_hold_em.rs
@@ -1713,10 +1713,11 @@ impl TexasHoldEm {
     /// new hand clears the internal event log, the progress methods notice the
     /// hand marker change and reset the cursor to the start of the new log.
     pub fn hand_event_cursor(&self) -> HandEventCursor {
+        let terminal_reported = matches!(self.event_log.last(), Some(GameEvent::HandComplete));
         HandEventCursor::from_parts(
             self.current_progress_hand_number(),
             u64::try_from(self.event_log.len()).unwrap_or(u64::MAX),
-            false,
+            terminal_reported,
         )
     }
 
@@ -4489,6 +4490,46 @@ mod tests {
                 assert_eq!(hand_number, first_hand_number + 1);
             }
             other => panic!("rebuilt cursor should advance to next hand, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hand_event_cursor_after_completed_log_starts_after_terminal_boundary() {
+        let mut game = TexasHoldEm::new_seeded(0, 10, 1, 2, 31);
+        seat_players(&mut game, &[100, 100, 100]);
+        let mut cursor = HandEventCursor::default();
+        let mut first_hand_number = None;
+
+        loop {
+            match game.drive_hand_progress(&mut cursor) {
+                HandProgressStep::Event(GameEvent::HandStarted { hand_number, .. }) => {
+                    first_hand_number = Some(hand_number);
+                }
+                HandProgressStep::Event(GameEvent::HandComplete) => break,
+                HandProgressStep::Event(_) => {}
+                HandProgressStep::AwaitingPlayer {
+                    player,
+                    decision_id,
+                } => {
+                    let pending = game.pending_action().unwrap();
+                    let action = ShoveAgent.decide(&pending.view).unwrap();
+                    game.submit_hand_progress_action(&mut cursor, player, decision_id, action)
+                        .unwrap();
+                }
+                HandProgressStep::HandComplete => panic!("terminal step precedes final event"),
+                HandProgressStep::CannotStart(error) => panic!("hand should start: {error}"),
+            }
+        }
+
+        let mut cursor = game.hand_event_cursor();
+        assert!(cursor.terminal_reported());
+
+        let first_hand_number = first_hand_number.expect("hand start was yielded");
+        match game.drive_hand_progress(&mut cursor) {
+            HandProgressStep::Event(GameEvent::HandStarted { hand_number, .. }) => {
+                assert_eq!(hand_number, first_hand_number + 1);
+            }
+            other => panic!("cursor should start the next hand, got {other:?}"),
         }
     }
 

--- a/crates/casino_poker/src/games/texas_hold_em.rs
+++ b/crates/casino_poker/src/games/texas_hold_em.rs
@@ -4263,6 +4263,65 @@ mod tests {
     }
 
     #[test]
+    fn restored_locked_showdown_does_not_repeat_hole_exposure() {
+        let original_log = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let mut game = TexasHoldEm::new_seeded(0, 10, 1, 2, 17);
+        seat_players(&mut game, &[100, 50, 75]);
+        game.set_observer(Box::new(RecordingObserver {
+            log: original_log.clone(),
+        }));
+        let mut agents = agents_all(&game, || Box::new(ShoveAgent));
+
+        game.begin_hand().unwrap();
+        assert_eq!(
+            game.run_betting_round(Street::Preflop, &mut agents),
+            Ok(RoundOutcome::Continue)
+        );
+        assert_eq!(
+            original_log
+                .borrow()
+                .iter()
+                .filter(|event| matches!(event, GameEvent::HoleCardsExposed { .. }))
+                .count(),
+            3,
+            "locked showdown holes are exposed before save"
+        );
+
+        let json = serde_json::to_string(&game).unwrap();
+        let mut restored: TexasHoldEm = serde_json::from_str(&json).unwrap();
+        let restored_log = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        restored.set_observer(Box::new(RecordingObserver {
+            log: restored_log.clone(),
+        }));
+
+        let mut step = restored.drive_hand();
+        while let HandStep::AwaitingAction(pending) = step {
+            let action = ShoveAgent.decide(&pending.view).unwrap();
+            step = restored
+                .submit_hand_action(pending.player, pending.decision_id, action)
+                .unwrap();
+        }
+        assert!(matches!(step, HandStep::HandComplete));
+
+        assert_eq!(
+            restored_log
+                .borrow()
+                .iter()
+                .filter(|event| matches!(event, GameEvent::HoleCardsExposed { .. }))
+                .count(),
+            0,
+            "restored run-out must not repeat exposure events already serialized"
+        );
+        assert!(
+            restored_log
+                .borrow()
+                .iter()
+                .any(|event| matches!(event, GameEvent::StreetDealt { .. })),
+            "restored hand still runs out the remaining board"
+        );
+    }
+
+    #[test]
     fn run_betting_round_exposes_when_covering_stack_has_chips_behind() {
         let log = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
         let mut game = TexasHoldEm::new(0, 10, 1, 2);

--- a/crates/casino_poker/src/games/texas_hold_em.rs
+++ b/crates/casino_poker/src/games/texas_hold_em.rs
@@ -585,6 +585,10 @@ pub struct TexasHoldEm {
     folded: HashSet<Uuid>,
     /// Players who are all-in this hand.
     all_in: HashSet<Uuid>,
+    /// Live players whose hole cards have already been publicly exposed after all
+    /// remaining action became locked.
+    #[serde(default)]
+    exposed_hole_cards: HashSet<Uuid>,
     /// Each player's two hole cards for the current hand.
     player_hands: HashMap<Uuid, Hand>,
     /// The shared community cards.
@@ -658,6 +662,7 @@ impl TexasHoldEm {
             contributed: HashMap::new(),
             folded: HashSet::new(),
             all_in: HashSet::new(),
+            exposed_hole_cards: HashSet::new(),
             player_hands: HashMap::new(),
             board: Hand::new(),
             burned: Hand::new(),
@@ -1290,6 +1295,7 @@ impl TexasHoldEm {
             || !self.contributed.is_empty()
             || !self.folded.is_empty()
             || !self.all_in.is_empty()
+            || !self.exposed_hole_cards.is_empty()
         {
             return Err(HandStartError::InvalidHandState);
         }
@@ -1345,6 +1351,7 @@ impl TexasHoldEm {
             .keys()
             .chain(self.folded.iter())
             .chain(self.all_in.iter())
+            .chain(self.exposed_hole_cards.iter())
             .chain(self.player_hands.keys())
             .all(|id| seated.contains(id));
         if !state_ids_are_seated {
@@ -1451,6 +1458,7 @@ impl TexasHoldEm {
         // hand. (Resume goes through `drive_hand`, not here, so it keeps the log.)
         self.event_log.clear();
         self.completed_betting_street = None;
+        self.exposed_hole_cards.clear();
         self.hand_number += 1;
         // Emitted before blinds are posted, so the seat stacks are pre-blind.
         let seats: Vec<SeatInfo> = self
@@ -1936,6 +1944,39 @@ impl TexasHoldEm {
         }
     }
 
+    fn expose_locked_showdown_holes(&mut self) {
+        if self.board.cards.len() >= 5 {
+            return;
+        }
+
+        let live: Vec<Uuid> = self
+            .seats
+            .iter()
+            .copied()
+            .filter(|id| !self.folded.contains(id))
+            .collect();
+        if live.len() <= 1 {
+            return;
+        }
+        let actionable_live_count = live.iter().filter(|id| !self.all_in.contains(id)).count();
+        if actionable_live_count > 1 {
+            return;
+        }
+
+        for id in live {
+            if !self.exposed_hole_cards.insert(id) {
+                continue;
+            }
+            let Some(player) = self.players.get(&id).map(Player::to_ref) else {
+                continue;
+            };
+            let Some(hole) = self.player_hands.get(&id).map(|hand| hand.cards.clone()) else {
+                continue;
+            };
+            self.emit(GameEvent::HoleCardsExposed { player, hole });
+        }
+    }
+
     /// The street whose betting an in-progress hand should (re)open, inferred from
     /// the community cards already dealt. Only used on the defensive resume path in
     /// [`drive_hand`] (a hand in progress with no active betting round).
@@ -2176,6 +2217,7 @@ impl TexasHoldEm {
                 || (actionable.len() == 1 && active.round.owed(actionable[0]) == 0)
             {
                 self.completed_betting_street = Some(active.street);
+                self.expose_locked_showdown_holes();
                 return BettingStep::RoundComplete(RoundOutcome::Continue);
             }
             if active.round.is_closed() {
@@ -2504,6 +2546,7 @@ impl TexasHoldEm {
         self.contributed.clear();
         self.folded.clear();
         self.all_in.clear();
+        self.exposed_hole_cards.clear();
         self.betting = None;
         self.completed_betting_street = None;
     }
@@ -4193,6 +4236,141 @@ mod tests {
     }
 
     #[test]
+    fn run_betting_round_exposes_locked_showdown_holes() {
+        let log = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let mut game = TexasHoldEm::new(0, 10, 1, 2);
+        seat_players(&mut game, &[100, 50, 75]);
+        game.set_observer(Box::new(RecordingObserver { log: log.clone() }));
+        let mut agents = agents_all(&game, || Box::new(ShoveAgent));
+
+        game.begin_hand().unwrap();
+        assert_eq!(
+            game.run_betting_round(Street::Preflop, &mut agents),
+            Ok(RoundOutcome::Continue)
+        );
+
+        let events = log.borrow();
+        let first_exposed = events
+            .iter()
+            .position(|event| matches!(event, GameEvent::HoleCardsExposed { .. }))
+            .expect("locked all-in players expose hole cards before the run-out");
+        assert!(
+            events[first_exposed..]
+                .iter()
+                .all(|event| !matches!(event, GameEvent::StreetDealt { .. })),
+            "manual round driving emits exposure before the caller deals more board cards"
+        );
+    }
+
+    #[test]
+    fn run_betting_round_exposes_when_covering_stack_has_chips_behind() {
+        let log = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let mut game = TexasHoldEm::new(0, 10, 1, 2);
+        let ids = seat_players(&mut game, &[100, 2, 1]);
+        game.set_observer(Box::new(RecordingObserver { log: log.clone() }));
+        let mut agents = agents_all(&game, || Box::new(CallingAgent));
+
+        game.begin_hand().unwrap();
+        assert_eq!(
+            game.run_betting_round(Street::Preflop, &mut agents),
+            Ok(RoundOutcome::Continue)
+        );
+
+        assert!(
+            !game.is_all_in(&ids[0]),
+            "the covering stack keeps chips behind after matching the short all-ins"
+        );
+        assert!(game.is_all_in(&ids[1]));
+        assert!(game.is_all_in(&ids[2]));
+        let events = log.borrow();
+        let exposed = events
+            .iter()
+            .filter(|event| matches!(event, GameEvent::HoleCardsExposed { .. }))
+            .count();
+        assert_eq!(
+            exposed, 3,
+            "all live players expose once betting is locked with one covering stack"
+        );
+    }
+
+    #[test]
+    fn run_betting_round_keeps_holes_hidden_when_live_players_can_still_bet() {
+        let log = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let mut game = TexasHoldEm::new(0, 10, 1, 2);
+        let ids = seat_players(&mut game, &[100, 100, 1]);
+        game.set_observer(Box::new(RecordingObserver { log: log.clone() }));
+        let mut agents = agents_all(&game, || Box::new(CallingAgent));
+
+        game.begin_hand().unwrap();
+        assert_eq!(
+            game.run_betting_round(Street::Preflop, &mut agents),
+            Ok(RoundOutcome::Continue)
+        );
+
+        assert!(!game.is_all_in(&ids[0]));
+        assert!(!game.is_all_in(&ids[1]));
+        assert!(game.is_all_in(&ids[2]));
+        assert!(
+            log.borrow()
+                .iter()
+                .all(|event| !matches!(event, GameEvent::HoleCardsExposed { .. })),
+            "one short all-in does not expose cards while multiple live players can bet future streets"
+        );
+    }
+
+    #[test]
+    fn full_board_showdown_does_not_emit_early_hole_exposure() {
+        let log = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let mut game = TexasHoldEm::new(0, 10, 1, 2);
+        let ids = seat_players(&mut game, &[100, 100]);
+        game.set_observer(Box::new(RecordingObserver { log: log.clone() }));
+        game.board = Hand::new_from_cards(vec![
+            card(Rank::Ace, Suit::Spade),
+            card(Rank::King, Suit::Heart),
+            card(Rank::Queen, Suit::Club),
+            card(Rank::Jack, Suit::Diamond),
+            card(Rank::Ten, Suit::Spade),
+        ]);
+        game.player_hands.insert(
+            ids[0],
+            Hand::new_from_cards(vec![
+                card(Rank::Ace, Suit::Heart),
+                card(Rank::King, Suit::Club),
+            ]),
+        );
+        game.player_hands.insert(
+            ids[1],
+            Hand::new_from_cards(vec![
+                card(Rank::Queen, Suit::Diamond),
+                card(Rank::Queen, Suit::Heart),
+            ]),
+        );
+        game.all_in.extend(ids);
+
+        game.expose_locked_showdown_holes();
+
+        assert!(
+            log.borrow()
+                .iter()
+                .all(|event| !matches!(event, GameEvent::HoleCardsExposed { .. })),
+            "after the river there is no early run-out exposure to emit"
+        );
+    }
+
+    #[test]
+    fn exposed_hole_card_state_must_reference_seated_players() {
+        let mut game = TexasHoldEm::new(0, 10, 1, 2);
+        seat_players(&mut game, &[100, 100]);
+        game.begin_hand().unwrap();
+        game.exposed_hole_cards.insert(Uuid::nil());
+
+        assert!(matches!(
+            game.drive_hand(),
+            HandStep::CannotStart(HandStartError::InvalidRoster)
+        ));
+    }
+
+    #[test]
     fn hand_progress_yields_all_in_runout_events_one_at_a_time() {
         let log = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
         let mut game = TexasHoldEm::new(0, 10, 1, 2);
@@ -4249,6 +4427,8 @@ mod tests {
         );
         let position = |pred: fn(&GameEvent) -> bool| events.iter().position(pred).unwrap();
         let last = |pred: fn(&GameEvent) -> bool| events.iter().rposition(pred).unwrap();
+        let first_exposed = position(|event| matches!(event, GameEvent::HoleCardsExposed { .. }));
+        let last_exposed = last(|event| matches!(event, GameEvent::HoleCardsExposed { .. }));
         let first_street = position(|event| matches!(event, GameEvent::StreetDealt { .. }));
         let last_street = last(|event| matches!(event, GameEvent::StreetDealt { .. }));
         let showdown = position(|event| matches!(event, GameEvent::Showdown { .. }));
@@ -4256,6 +4436,8 @@ mod tests {
         let first_award = position(|event| matches!(event, GameEvent::PotAwarded { .. }));
         let complete = position(|event| matches!(event, GameEvent::HandComplete));
 
+        assert!(first_exposed < last_exposed);
+        assert!(last_exposed < first_street);
         assert!(first_street < last_street);
         assert!(last_street < showdown);
         assert!(showdown < first_reveal);

--- a/crates/casino_poker/src/games/texas_hold_em.rs
+++ b/crates/casino_poker/src/games/texas_hold_em.rs
@@ -122,6 +122,10 @@ pub enum RoundOutcome {
 pub struct DecisionId(u64);
 
 /// One identified player decision yielded by either state machine.
+///
+/// The [`PlayerView`] belongs only to `player`: it includes that player's private
+/// hole cards and other actor-specific decision context. Do not broadcast a
+/// `PendingAction` to the table.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PendingAction {
     /// Stable identity for this decision.
@@ -274,6 +278,91 @@ pub enum HandStep {
     HandComplete,
     /// A fresh hand could not start; the engine was not mutated.
     CannotStart(HandStartError),
+}
+
+/// External position in a hand's event stream.
+///
+/// Keep this alongside the serialized engine state when consuming
+/// [`HandProgressStep`]s. The cursor is intentionally external so
+/// [`TexasHoldEm`]'s serialized layout is unchanged.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct HandEventCursor {
+    /// Hand whose event log this cursor is positioned in.
+    hand_number: Option<u32>,
+    /// Index of the next event to yield from the current hand's event log.
+    next_event: u64,
+}
+
+impl Default for HandEventCursor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HandEventCursor {
+    /// Return a cursor positioned at the beginning of the next observed hand log.
+    pub fn new() -> Self {
+        Self {
+            hand_number: None,
+            next_event: 0,
+        }
+    }
+
+    /// Rebuild a cursor from durable parts.
+    pub fn from_parts(hand_number: Option<u32>, next_event: u64) -> Self {
+        Self {
+            hand_number,
+            next_event,
+        }
+    }
+
+    /// Hand marker this cursor is currently associated with.
+    pub fn hand_number(&self) -> Option<u32> {
+        self.hand_number
+    }
+
+    /// Durable event offset within the current hand's event log.
+    pub fn next_event(&self) -> u64 {
+        self.next_event
+    }
+}
+
+/// One fine-grained hand progression item.
+///
+/// `Event` values are public/broadcast-safe and match [`public_events`](TexasHoldEm::public_events)
+/// redaction: private hole-card payloads are omitted, while showdown reveals remain
+/// public. `AwaitingPlayer` identifies the pending decision without carrying the
+/// acting player's private prompt; retrieve that prompt through
+/// [`TexasHoldEm::pending_action`] or [`TexasHoldEm::client_view`].
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum HandProgressStep {
+    /// One newly emitted public hand event.
+    Event(GameEvent),
+    /// Paused on one identified player decision.
+    AwaitingPlayer {
+        /// Player expected to act.
+        player: Uuid,
+        /// Stable identity for this decision.
+        decision_id: DecisionId,
+    },
+    /// The hand is fully played, awarded, and ended.
+    HandComplete,
+    /// A fresh hand could not start; the engine was not mutated.
+    CannotStart(HandStartError),
+}
+
+impl From<HandStep> for HandProgressStep {
+    fn from(step: HandStep) -> Self {
+        match step {
+            HandStep::AwaitingAction(pending) => Self::AwaitingPlayer {
+                player: pending.player,
+                decision_id: pending.decision_id,
+            },
+            HandStep::HandComplete => Self::HandComplete,
+            HandStep::CannotStart(error) => Self::CannotStart(error),
+        }
+    }
 }
 
 /// The result of driving a whole hand with [`play_hand`](TexasHoldEm::play_hand):
@@ -663,6 +752,35 @@ impl TexasHoldEm {
                 event => event,
             })
             .collect()
+    }
+
+    fn public_event_at(&self, index: usize) -> Option<GameEvent> {
+        self.events_for(None).into_iter().nth(index)
+    }
+
+    fn current_progress_hand_number(&self) -> Option<u32> {
+        self.event_log.first().and_then(|event| match event {
+            GameEvent::HandStarted { hand_number, .. } => Some(*hand_number),
+            _ => None,
+        })
+    }
+
+    fn next_progress_event(&self, cursor: &mut HandEventCursor) -> Option<GameEvent> {
+        let hand_number = self.current_progress_hand_number();
+        if cursor.hand_number != hand_number {
+            cursor.hand_number = hand_number;
+            cursor.next_event = 0;
+        }
+        let index = match usize::try_from(cursor.next_event) {
+            Ok(index) if index <= self.event_log.len() => index,
+            _ => {
+                cursor.next_event = 0;
+                0
+            }
+        };
+        let event = self.public_event_at(index)?;
+        cursor.next_event += 1;
+        Some(event)
     }
 
     /// Create a new player with zero chips.
@@ -1559,6 +1677,44 @@ impl TexasHoldEm {
         self.drive_hand_from(street, step)
     }
 
+    /// Return a cursor positioned after the events currently recorded for this
+    /// hand.
+    ///
+    /// Store the cursor outside the engine and pass it back to
+    /// [`drive_hand_progress`](Self::drive_hand_progress) or
+    /// [`submit_hand_progress_action`](Self::submit_hand_progress_action). If a
+    /// new hand clears the internal event log, the progress methods notice the
+    /// hand marker change and reset the cursor to the start of the new log.
+    pub fn hand_event_cursor(&self) -> HandEventCursor {
+        HandEventCursor::from_parts(
+            self.current_progress_hand_number(),
+            u64::try_from(self.event_log.len()).unwrap_or(u64::MAX),
+        )
+    }
+
+    /// Drive a whole hand one progression item at a time.
+    ///
+    /// Events are yielded from the hand's real event log in order and are
+    /// public/redacted. `AwaitingPlayer` contains only the acting player and
+    /// decision identity; use [`pending_action`](Self::pending_action) or
+    /// [`client_view`](Self::client_view) to retrieve the private prompt. This
+    /// method does not replay the log or notify observers itself, so it does not
+    /// duplicate observer notifications emitted by normal engine advancement.
+    /// After the final public
+    /// [`GameEvent::HandComplete`] event has been drained, the next call follows
+    /// [`drive_hand`](Self::drive_hand) by starting a fresh hand when possible.
+    pub fn drive_hand_progress(&mut self, cursor: &mut HandEventCursor) -> HandProgressStep {
+        if let Some(event) = self.next_progress_event(cursor) {
+            return HandProgressStep::Event(event);
+        }
+
+        let step = self.drive_hand();
+        if let Some(event) = self.next_progress_event(cursor) {
+            return HandProgressStep::Event(event);
+        }
+        step.into()
+    }
+
     /// Submit the player, decision identity, and action yielded by
     /// [`drive_hand`](Self::drive_hand), returning the next [`HandStep`].
     ///
@@ -1578,6 +1734,32 @@ impl TexasHoldEm {
             .ok_or(ActionSubmissionError::NoActionPending)?;
         let step = self.submit_action(player, decision_id, action)?;
         Ok(self.drive_hand_from(street, step))
+    }
+
+    /// Submit an action for a pending [`HandProgressStep::AwaitingPlayer`] and
+    /// return the next progression item.
+    ///
+    /// If `cursor` still has an undrained public event, this returns that event
+    /// without applying the action. Callers should drain it first, then resubmit
+    /// the same player, decision identity, and action. This keeps public events
+    /// ordered before any mutation caused by the action. Returned `Event`
+    /// payloads are public/redacted. A returned `AwaitingPlayer` identifies the
+    /// next acting player without exposing their private prompt.
+    pub fn submit_hand_progress_action(
+        &mut self,
+        cursor: &mut HandEventCursor,
+        player: Uuid,
+        decision_id: DecisionId,
+        action: PlayerAction,
+    ) -> Result<HandProgressStep, ActionSubmissionError> {
+        if let Some(event) = self.next_progress_event(cursor) {
+            return Ok(HandProgressStep::Event(event));
+        }
+        let step = self.submit_hand_action(player, decision_id, action)?;
+        if let Some(event) = self.next_progress_event(cursor) {
+            return Ok(HandProgressStep::Event(event));
+        }
+        Ok(step.into())
     }
 
     /// Blocking convenience over [`Self::drive_hand`]/[`Self::submit_hand_action`]:
@@ -3927,6 +4109,140 @@ mod tests {
     }
 
     #[test]
+    fn hand_progress_yields_all_in_runout_events_one_at_a_time() {
+        let log = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let mut game = TexasHoldEm::new(0, 10, 1, 2);
+        seat_players(&mut game, &[100, 50, 75]);
+        game.set_observer(Box::new(RecordingObserver { log: log.clone() }));
+        let mut cursor = HandEventCursor::default();
+        let mut events = Vec::new();
+        let mut next = Some(game.drive_hand_progress(&mut cursor));
+
+        loop {
+            match next.take().unwrap() {
+                HandProgressStep::Event(event) => {
+                    let hand_complete = matches!(event, GameEvent::HandComplete);
+                    events.push(event);
+                    if hand_complete {
+                        break;
+                    }
+                    next = Some(game.drive_hand_progress(&mut cursor));
+                }
+                HandProgressStep::AwaitingPlayer {
+                    player,
+                    decision_id,
+                } => {
+                    let pending = game.pending_action().expect("private prompt is available");
+                    assert_eq!(pending.player, player);
+                    assert_eq!(pending.decision_id, decision_id);
+                    let action = ShoveAgent.decide(&pending.view).unwrap();
+                    next = Some(
+                        game.submit_hand_progress_action(&mut cursor, player, decision_id, action)
+                            .unwrap(),
+                    );
+                }
+                HandProgressStep::HandComplete => {
+                    panic!("progress should yield the public HandComplete event")
+                }
+                HandProgressStep::CannotStart(error) => {
+                    panic!("hand should start and finish: {error}")
+                }
+            }
+        }
+
+        assert_eq!(
+            events,
+            *log.borrow(),
+            "progress drains the real event log without duplicate observer notifications"
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, GameEvent::StreetDealt { .. }))
+                .count(),
+            3,
+            "flop, turn, and river are yielded as separate events"
+        );
+        let position = |pred: fn(&GameEvent) -> bool| events.iter().position(pred).unwrap();
+        let last = |pred: fn(&GameEvent) -> bool| events.iter().rposition(pred).unwrap();
+        let first_street = position(|event| matches!(event, GameEvent::StreetDealt { .. }));
+        let last_street = last(|event| matches!(event, GameEvent::StreetDealt { .. }));
+        let showdown = position(|event| matches!(event, GameEvent::Showdown { .. }));
+        let first_reveal = position(|event| matches!(event, GameEvent::ShowdownReveal { .. }));
+        let first_award = position(|event| matches!(event, GameEvent::PotAwarded { .. }));
+        let complete = position(|event| matches!(event, GameEvent::HandComplete));
+
+        assert!(first_street < last_street);
+        assert!(last_street < showdown);
+        assert!(showdown < first_reveal);
+        assert!(first_reveal < first_award);
+        assert!(first_award < complete);
+        assert!(matches!(events.last(), Some(GameEvent::HandComplete)));
+    }
+
+    #[test]
+    fn hand_progress_starts_next_hand_after_final_event_is_drained() {
+        let mut game = TexasHoldEm::new_seeded(0, 10, 1, 2, 31);
+        seat_players(&mut game, &[100, 100, 100]);
+        let mut cursor = HandEventCursor::default();
+
+        let mut step = game.drive_hand_progress(&mut cursor);
+        let first_hand_number = loop {
+            match step {
+                HandProgressStep::Event(GameEvent::HandStarted { hand_number, .. }) => {
+                    break hand_number;
+                }
+                HandProgressStep::Event(_) => {
+                    step = game.drive_hand_progress(&mut cursor);
+                }
+                HandProgressStep::AwaitingPlayer { .. } => {
+                    panic!("hand should emit its start before awaiting action")
+                }
+                HandProgressStep::HandComplete => panic!("hand completed before it started"),
+                HandProgressStep::CannotStart(error) => panic!("hand should start: {error}"),
+            }
+        };
+
+        loop {
+            match step {
+                HandProgressStep::Event(GameEvent::HandComplete) => break,
+                HandProgressStep::Event(_) => {
+                    step = game.drive_hand_progress(&mut cursor);
+                }
+                HandProgressStep::AwaitingPlayer {
+                    player,
+                    decision_id,
+                } => {
+                    let view = game.client_view(player);
+                    let pending = view
+                        .pending_action
+                        .expect("acting player's private prompt is available");
+                    assert_eq!(pending.decision_id, decision_id);
+                    let action = ShoveAgent.decide(&pending.view).unwrap();
+                    step = game
+                        .submit_hand_progress_action(&mut cursor, player, decision_id, action)
+                        .unwrap();
+                }
+                HandProgressStep::HandComplete => {
+                    panic!("final HandComplete event should be yielded before terminal step")
+                }
+                HandProgressStep::CannotStart(error) => {
+                    panic!("hand should finish cleanly: {error}")
+                }
+            }
+        }
+
+        assert!(!game.hand_in_progress(), "first hand is fully resolved");
+
+        match game.drive_hand_progress(&mut cursor) {
+            HandProgressStep::Event(GameEvent::HandStarted { hand_number, .. }) => {
+                assert_eq!(hand_number, first_hand_number + 1);
+            }
+            other => panic!("expected next hand to start after draining completion, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn play_hand_awards_without_flop_when_all_fold_preflop() {
         let log = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
         let mut game = TexasHoldEm::new(0, 10, 1, 2);
@@ -4026,6 +4342,115 @@ mod tests {
         );
         assert_eq!(game.board().cards, board_before, "no re-deal");
         assert_eq!(game.deck_len(), deck_before, "no cards drawn");
+    }
+
+    #[test]
+    fn hand_progress_cursor_round_trips_through_json() {
+        let cursor = HandEventCursor::from_parts(Some(3), 7);
+        let json = serde_json::to_string(&cursor).unwrap();
+        let restored: HandEventCursor = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, cursor);
+        assert_eq!(restored.hand_number(), Some(3));
+        assert_eq!(restored.next_event(), 7);
+    }
+
+    #[test]
+    fn hand_progress_events_use_public_redaction() {
+        let mut game = TexasHoldEm::new_seeded(0, 10, 1, 2, 23);
+        let ids = seat_players(&mut game, &[100, 100, 100]);
+        game.set_hero(ids[0]);
+        let mut cursor = HandEventCursor::default();
+
+        loop {
+            match game.drive_hand_progress(&mut cursor) {
+                HandProgressStep::Event(GameEvent::HoleCardsDealt { hero }) => {
+                    assert_eq!(hero, None);
+                    break;
+                }
+                HandProgressStep::Event(_) => {}
+                HandProgressStep::AwaitingPlayer { .. } => {
+                    panic!("hole-card event should be yielded before the first action")
+                }
+                HandProgressStep::HandComplete => panic!("hand completed before hole-card event"),
+                HandProgressStep::CannotStart(error) => panic!("hand should start: {error}"),
+            }
+        }
+    }
+
+    #[test]
+    fn hand_progress_awaiting_player_is_public_safe_marker() {
+        let mut game = TexasHoldEm::new_seeded(0, 10, 1, 2, 29);
+        seat_players(&mut game, &[100, 100]);
+        let mut cursor = HandEventCursor::default();
+
+        loop {
+            match game.drive_hand_progress(&mut cursor) {
+                HandProgressStep::Event(_) => {}
+                HandProgressStep::AwaitingPlayer {
+                    player,
+                    decision_id,
+                } => {
+                    let pending = game
+                        .pending_action()
+                        .expect("private prompt remains available");
+                    assert_eq!(pending.player, player);
+                    assert_eq!(pending.decision_id, decision_id);
+                    assert!(game.client_view(player).pending_action.is_some());
+                    break;
+                }
+                HandProgressStep::HandComplete => panic!("hand completed before action"),
+                HandProgressStep::CannotStart(error) => panic!("hand should start: {error}"),
+            }
+        }
+    }
+
+    #[test]
+    fn submit_hand_progress_action_drains_pending_event_before_mutating() {
+        let mut game = TexasHoldEm::new_seeded(0, 10, 1, 2, 29);
+        seat_players(&mut game, &[100, 100]);
+        let mut cursor = HandEventCursor::default();
+        let HandStep::AwaitingAction(pending) = game.drive_hand() else {
+            panic!("expected a pending action");
+        };
+        assert_eq!(
+            cursor.next_event(),
+            0,
+            "cursor has not drained hand-start event"
+        );
+
+        let before = serde_json::to_string(&game).unwrap();
+        let step = game
+            .submit_hand_progress_action(
+                &mut cursor,
+                pending.player,
+                pending.decision_id,
+                PlayerAction::Call,
+            )
+            .unwrap();
+
+        assert!(matches!(
+            step,
+            HandProgressStep::Event(GameEvent::HandStarted { .. })
+        ));
+        assert_eq!(
+            serde_json::to_string(&game).unwrap(),
+            before,
+            "action is not applied until earlier events are drained"
+        );
+        assert!(game.pending_action().is_some());
+    }
+
+    #[test]
+    fn drive_hand_behavior_is_unchanged_after_progress_api_addition() {
+        let mut game = TexasHoldEm::new_seeded(0, 10, 1, 2, 29);
+        seat_players(&mut game, &[100, 100]);
+        let HandStep::AwaitingAction(pending) = game.drive_hand() else {
+            panic!("drive_hand should still yield an action boundary");
+        };
+        assert!(matches!(
+            game.submit_hand_action(pending.player, pending.decision_id, PlayerAction::Call),
+            Ok(HandStep::AwaitingAction(_))
+        ));
     }
 
     #[test]

--- a/crates/casino_poker/tests/downstream_api.rs
+++ b/crates/casino_poker/tests/downstream_api.rs
@@ -1,7 +1,10 @@
 use casino_poker::agent::{AgentError, PlayerView, PokerAgent};
-use casino_poker::betting::PlayerAction;
+use casino_poker::betting::{LegalAction, PlayerAction};
 use casino_poker::casino_cards::card::{Card, Rank, Suit};
-use casino_poker::games::texas_hold_em::SeatView;
+use casino_poker::events::GameEvent;
+use casino_poker::games::texas_hold_em::{
+    HandEventCursor, HandProgressStep, SeatView, TexasHoldEm,
+};
 use casino_poker::hand_rankings::{evaluate_holdem, EvaluatedHand, HandCategory};
 use casino_poker::uuid::Uuid;
 
@@ -20,6 +23,22 @@ fn classify_agent_error(error: &AgentError) -> &'static str {
         AgentError::InvalidView => "invalid-view",
         AgentError::Failure(_) => "failure",
         _ => "future-error",
+    }
+}
+
+fn choose_public_action(legal_actions: &[LegalAction]) -> PlayerAction {
+    if legal_actions
+        .iter()
+        .any(|action| matches!(action, LegalAction::Check))
+    {
+        PlayerAction::Check
+    } else if legal_actions
+        .iter()
+        .any(|action| matches!(action, LegalAction::Call(_)))
+    {
+        PlayerAction::Call
+    } else {
+        PlayerAction::Fold
     }
 }
 
@@ -102,4 +121,92 @@ fn external_consumers_can_build_seat_views_for_player_view_tests() {
     assert_eq!(view.seats[1].contributed_this_hand, 4);
     assert!(view.seats[1].folded);
     assert!(view.seats[1].all_in);
+}
+
+#[test]
+fn external_consumers_can_drive_public_hand_progress_without_leaking_prompts() {
+    let mut game = TexasHoldEm::new_seeded(0, 10, 1, 2, 42);
+    for name in ["Ada", "Bert", "Cyd"] {
+        let player = game.new_player_with_chips(name, 100);
+        game.add_player(player).unwrap();
+    }
+
+    let mut cursor = HandEventCursor::default();
+    let first_step = game.drive_hand_progress(&mut cursor);
+    assert!(matches!(
+        first_step,
+        HandProgressStep::Event(GameEvent::HandStarted { .. })
+    ));
+
+    let encoded_cursor = serde_json::to_string(&cursor).unwrap();
+    let mut cursor: HandEventCursor = serde_json::from_str(&encoded_cursor).unwrap();
+    assert_eq!(cursor.next_event(), 1);
+    let mut public_stream = Vec::new();
+
+    let (actor, decision_id) = loop {
+        match game.drive_hand_progress(&mut cursor) {
+            HandProgressStep::Event(GameEvent::HoleCardsDealt { hero }) => {
+                assert!(
+                    hero.is_none(),
+                    "progress events use the public/redacted event stream"
+                );
+                public_stream.push(GameEvent::HoleCardsDealt { hero });
+            }
+            HandProgressStep::Event(event) => public_stream.push(event),
+            HandProgressStep::AwaitingPlayer {
+                player,
+                decision_id,
+            } => break (player, decision_id),
+            HandProgressStep::HandComplete => panic!("hand should await a preflop action"),
+            HandProgressStep::CannotStart(error) => panic!("hand should start: {error}"),
+            _ => panic!("unexpected future hand progress step"),
+        }
+    };
+
+    let pending = game
+        .pending_action()
+        .expect("the private prompt is available through pending_action");
+    assert_eq!(pending.player, actor);
+    assert_eq!(pending.decision_id, decision_id);
+    assert_eq!(pending.view.you, actor);
+    assert_eq!(pending.view.hole.len(), 2);
+
+    let actor_view = game.client_view(actor);
+    let actor_prompt = actor_view
+        .pending_action
+        .expect("the actor can fetch their private prompt");
+    assert_eq!(actor_prompt.decision_id, decision_id);
+    assert!(actor_view.hole.is_some());
+
+    let spectator = game
+        .seats()
+        .iter()
+        .copied()
+        .find(|&player| player != actor)
+        .unwrap();
+    let spectator_view = game.client_view(spectator);
+    assert!(spectator_view.pending_action.is_none());
+    assert!(spectator_view.hole.is_some());
+
+    let action = choose_public_action(&actor_prompt.view.legal_actions);
+    let next = game
+        .submit_hand_progress_action(&mut cursor, actor, decision_id, action)
+        .unwrap();
+    match next {
+        HandProgressStep::Event(event) => {
+            if let GameEvent::ActionTaken { player, .. } = &event {
+                assert_eq!(player.id, actor);
+            }
+            public_stream.push(event);
+        }
+        HandProgressStep::AwaitingPlayer { .. } | HandProgressStep::HandComplete => {}
+        HandProgressStep::CannotStart(error) => panic!("hand should continue: {error}"),
+        _ => panic!("unexpected future hand progress step"),
+    }
+    assert!(
+        public_stream.iter().any(
+            |event| matches!(event, GameEvent::ActionTaken { player, .. } if player.id == actor)
+        ),
+        "consumers must preserve the post-submit step returned by submit_hand_progress_action"
+    );
 }

--- a/docs/public-api/casino_poker-1.0.txt
+++ b/docs/public-api/casino_poker-1.0.txt
@@ -312,6 +312,9 @@ pub casino_poker::events::GameEvent::HandStarted::seats: alloc::vec::Vec<casino_
 pub casino_poker::events::GameEvent::HandStarted::small_blind: u32
 pub casino_poker::events::GameEvent::HoleCardsDealt
 pub casino_poker::events::GameEvent::HoleCardsDealt::hero: core::option::Option<(casino_poker::player::PlayerRef, alloc::vec::Vec<casino_cards::card::Card>)>
+pub casino_poker::events::GameEvent::HoleCardsExposed
+pub casino_poker::events::GameEvent::HoleCardsExposed::hole: alloc::vec::Vec<casino_cards::card::Card>
+pub casino_poker::events::GameEvent::HoleCardsExposed::player: casino_poker::player::PlayerRef
 pub casino_poker::events::GameEvent::PotAwarded
 pub casino_poker::events::GameEvent::PotAwarded::amount: u32
 pub casino_poker::events::GameEvent::PotAwarded::hand: core::option::Option<casino_poker::hand_rankings::ComparableHand>

--- a/docs/public-api/casino_poker-1.0.txt
+++ b/docs/public-api/casino_poker-1.0.txt
@@ -447,6 +447,23 @@ impl serde_core::ser::Serialize for casino_poker::games::texas_hold_em::HandOutc
 pub fn casino_poker::games::texas_hold_em::HandOutcome::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for casino_poker::games::texas_hold_em::HandOutcome
 pub fn casino_poker::games::texas_hold_em::HandOutcome::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+#[non_exhaustive] pub enum casino_poker::games::texas_hold_em::HandProgressStep
+pub casino_poker::games::texas_hold_em::HandProgressStep::AwaitingPlayer
+pub casino_poker::games::texas_hold_em::HandProgressStep::AwaitingPlayer::decision_id: casino_poker::games::texas_hold_em::DecisionId
+pub casino_poker::games::texas_hold_em::HandProgressStep::AwaitingPlayer::player: uuid::Uuid
+pub casino_poker::games::texas_hold_em::HandProgressStep::CannotStart(casino_poker::games::texas_hold_em::HandStartError)
+pub casino_poker::games::texas_hold_em::HandProgressStep::Event(casino_poker::events::GameEvent)
+pub casino_poker::games::texas_hold_em::HandProgressStep::HandComplete
+impl core::clone::Clone for casino_poker::games::texas_hold_em::HandProgressStep
+pub fn casino_poker::games::texas_hold_em::HandProgressStep::clone(&self) -> casino_poker::games::texas_hold_em::HandProgressStep
+impl core::convert::From<casino_poker::games::texas_hold_em::HandStep> for casino_poker::games::texas_hold_em::HandProgressStep
+pub fn casino_poker::games::texas_hold_em::HandProgressStep::from(casino_poker::games::texas_hold_em::HandStep) -> Self
+impl core::fmt::Debug for casino_poker::games::texas_hold_em::HandProgressStep
+pub fn casino_poker::games::texas_hold_em::HandProgressStep::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for casino_poker::games::texas_hold_em::HandProgressStep
+pub fn casino_poker::games::texas_hold_em::HandProgressStep::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for casino_poker::games::texas_hold_em::HandProgressStep
+pub fn casino_poker::games::texas_hold_em::HandProgressStep::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 #[non_exhaustive] pub enum casino_poker::games::texas_hold_em::HandStartError
 pub casino_poker::games::texas_hold_em::HandStartError::ChipTotalTooLarge
 pub casino_poker::games::texas_hold_em::HandStartError::DuplicateCards
@@ -483,6 +500,8 @@ pub casino_poker::games::texas_hold_em::HandStep::CannotStart(casino_poker::game
 pub casino_poker::games::texas_hold_em::HandStep::HandComplete
 impl core::clone::Clone for casino_poker::games::texas_hold_em::HandStep
 pub fn casino_poker::games::texas_hold_em::HandStep::clone(&self) -> casino_poker::games::texas_hold_em::HandStep
+impl core::convert::From<casino_poker::games::texas_hold_em::HandStep> for casino_poker::games::texas_hold_em::HandProgressStep
+pub fn casino_poker::games::texas_hold_em::HandProgressStep::from(casino_poker::games::texas_hold_em::HandStep) -> Self
 impl core::fmt::Debug for casino_poker::games::texas_hold_em::HandStep
 pub fn casino_poker::games::texas_hold_em::HandStep::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl serde_core::ser::Serialize for casino_poker::games::texas_hold_em::HandStep
@@ -560,6 +579,29 @@ impl serde_core::ser::Serialize for casino_poker::games::texas_hold_em::Decision
 pub fn casino_poker::games::texas_hold_em::DecisionId::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
 impl<'de> serde_core::de::Deserialize<'de> for casino_poker::games::texas_hold_em::DecisionId
 pub fn casino_poker::games::texas_hold_em::DecisionId::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+pub struct casino_poker::games::texas_hold_em::HandEventCursor
+impl casino_poker::games::texas_hold_em::HandEventCursor
+pub fn casino_poker::games::texas_hold_em::HandEventCursor::from_parts(core::option::Option<u32>, u64) -> Self
+pub fn casino_poker::games::texas_hold_em::HandEventCursor::hand_number(&self) -> core::option::Option<u32>
+pub fn casino_poker::games::texas_hold_em::HandEventCursor::new() -> Self
+pub fn casino_poker::games::texas_hold_em::HandEventCursor::next_event(&self) -> u64
+impl core::clone::Clone for casino_poker::games::texas_hold_em::HandEventCursor
+pub fn casino_poker::games::texas_hold_em::HandEventCursor::clone(&self) -> casino_poker::games::texas_hold_em::HandEventCursor
+impl core::cmp::Eq for casino_poker::games::texas_hold_em::HandEventCursor
+impl core::cmp::PartialEq for casino_poker::games::texas_hold_em::HandEventCursor
+pub fn casino_poker::games::texas_hold_em::HandEventCursor::eq(&self, &casino_poker::games::texas_hold_em::HandEventCursor) -> bool
+impl core::default::Default for casino_poker::games::texas_hold_em::HandEventCursor
+pub fn casino_poker::games::texas_hold_em::HandEventCursor::default() -> Self
+impl core::fmt::Debug for casino_poker::games::texas_hold_em::HandEventCursor
+pub fn casino_poker::games::texas_hold_em::HandEventCursor::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for casino_poker::games::texas_hold_em::HandEventCursor
+pub fn casino_poker::games::texas_hold_em::HandEventCursor::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for casino_poker::games::texas_hold_em::HandEventCursor
+impl core::marker::StructuralPartialEq for casino_poker::games::texas_hold_em::HandEventCursor
+impl serde_core::ser::Serialize for casino_poker::games::texas_hold_em::HandEventCursor
+pub fn casino_poker::games::texas_hold_em::HandEventCursor::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for casino_poker::games::texas_hold_em::HandEventCursor
+pub fn casino_poker::games::texas_hold_em::HandEventCursor::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 pub struct casino_poker::games::texas_hold_em::PendingAction
 pub casino_poker::games::texas_hold_em::PendingAction::decision_id: casino_poker::games::texas_hold_em::DecisionId
 pub casino_poker::games::texas_hold_em::PendingAction::player: uuid::Uuid
@@ -634,12 +676,14 @@ pub fn casino_poker::games::texas_hold_em::TexasHoldEm::current_bet(&self) -> u3
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::current_street(&self) -> core::option::Option<casino_poker::agent::Street>
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::dealer(&self) -> core::option::Option<uuid::Uuid>
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::drive_hand(&mut self) -> casino_poker::games::texas_hold_em::HandStep
+pub fn casino_poker::games::texas_hold_em::TexasHoldEm::drive_hand_progress(&mut self, &mut casino_poker::games::texas_hold_em::HandEventCursor) -> casino_poker::games::texas_hold_em::HandProgressStep
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::end_game(&mut self)
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::get_big_blind_amount(&self) -> u32
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::get_big_blind_seat_index(&self) -> usize
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::get_small_blind_amount(&self) -> u32
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::get_small_blind_seat_index(&self) -> usize
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::get_under_the_gun_seat_index(&self) -> usize
+pub fn casino_poker::games::texas_hold_em::TexasHoldEm::hand_event_cursor(&self) -> casino_poker::games::texas_hold_em::HandEventCursor
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::hand_in_progress(&self) -> bool
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::has_folded(&self, &uuid::Uuid) -> bool
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::is_all_in(&self, &uuid::Uuid) -> bool
@@ -669,6 +713,7 @@ pub fn casino_poker::games::texas_hold_em::TexasHoldEm::set_min_buy_in(&mut self
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::set_observer(&mut self, alloc::boxed::Box<dyn casino_poker::events::GameObserver>)
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::submit_action(&mut self, uuid::Uuid, casino_poker::games::texas_hold_em::DecisionId, casino_poker::betting::PlayerAction) -> core::result::Result<casino_poker::games::texas_hold_em::BettingStep, casino_poker::games::texas_hold_em::ActionSubmissionError>
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::submit_hand_action(&mut self, uuid::Uuid, casino_poker::games::texas_hold_em::DecisionId, casino_poker::betting::PlayerAction) -> core::result::Result<casino_poker::games::texas_hold_em::HandStep, casino_poker::games::texas_hold_em::ActionSubmissionError>
+pub fn casino_poker::games::texas_hold_em::TexasHoldEm::submit_hand_progress_action(&mut self, &mut casino_poker::games::texas_hold_em::HandEventCursor, uuid::Uuid, casino_poker::games::texas_hold_em::DecisionId, casino_poker::betting::PlayerAction) -> core::result::Result<casino_poker::games::texas_hold_em::HandProgressStep, casino_poker::games::texas_hold_em::ActionSubmissionError>
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::table(&self) -> casino_poker::games::texas_hold_em::TableView
 pub fn casino_poker::games::texas_hold_em::TexasHoldEm::to_act(&self) -> core::option::Option<uuid::Uuid>
 impl core::default::Default for casino_poker::games::texas_hold_em::TexasHoldEm

--- a/docs/public-api/casino_poker-1.0.txt
+++ b/docs/public-api/casino_poker-1.0.txt
@@ -581,10 +581,11 @@ impl<'de> serde_core::de::Deserialize<'de> for casino_poker::games::texas_hold_e
 pub fn casino_poker::games::texas_hold_em::DecisionId::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
 pub struct casino_poker::games::texas_hold_em::HandEventCursor
 impl casino_poker::games::texas_hold_em::HandEventCursor
-pub fn casino_poker::games::texas_hold_em::HandEventCursor::from_parts(core::option::Option<u32>, u64) -> Self
+pub fn casino_poker::games::texas_hold_em::HandEventCursor::from_parts(core::option::Option<u32>, u64, bool) -> Self
 pub fn casino_poker::games::texas_hold_em::HandEventCursor::hand_number(&self) -> core::option::Option<u32>
 pub fn casino_poker::games::texas_hold_em::HandEventCursor::new() -> Self
 pub fn casino_poker::games::texas_hold_em::HandEventCursor::next_event(&self) -> u64
+pub fn casino_poker::games::texas_hold_em::HandEventCursor::terminal_reported(&self) -> bool
 impl core::clone::Clone for casino_poker::games::texas_hold_em::HandEventCursor
 pub fn casino_poker::games::texas_hold_em::HandEventCursor::clone(&self) -> casino_poker::games::texas_hold_em::HandEventCursor
 impl core::cmp::Eq for casino_poker::games::texas_hold_em::HandEventCursor


### PR DESCRIPTION
## Summary

Adds a public Texas Hold'em hand progress stream API so clients can observe a hand as ordered, visibility-safe progress events instead of reconstructing UI timing from final hand history output.

This supports UI consumers that need to stream blinds, deal events, player actions, board cards, showdown reveals, pot returns, and hand completion without leaking private hole-card information.

## Changes

- Adds structured hand progress events for Texas Hold'em hand flow.
- Preserves private-information boundaries by exposing hero-safe / observer-safe event data.
- Keeps existing hand history capture intact while allowing consumers to render progress incrementally.
- Adds tests for event ordering, visibility behavior, showdown reveals, and hand completion boundaries.
- Updates crate metadata/changelog for the public API change.